### PR TITLE
cross platform implementation of copy_directory

### DIFF
--- a/R/gcloud-utils.R
+++ b/R/gcloud-utils.R
@@ -41,12 +41,15 @@ scope_deployment <- function(application = getwd(), config) {
 
   # default excludes plus any additional excludes in the config file
   config <- cloudml::config(config = config)
-  exclude <- c("local", "jobs")
+  exclude <- c("local", "jobs", ".git", ".svn")
   exclude <- unique(c(exclude, config$exclude))
 
   # build deployment bundle
   deployment <- file.path(root, basename(application))
-  copy_directory(application, deployment, exclude = exclude)
+  copy_directory(application,
+                 deployment,
+                 exclude = exclude,
+                 include = config$include)
   defer(unlink(root, recursive = TRUE), envir = parent.frame())
   initialize_application(deployment)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -37,10 +37,10 @@ copy_directory <- function(source,
   dir.create(target)
 
   # get the original top level file listing
-  all_files <- list.files(source, all.files = TRUE)
+  all_files <- list.files(source, all.files = TRUE, no.. = TRUE)
 
   # apply excludes to the top level listing
-  exclude <- c("^\\..*$", utils::glob2rx(exclude))
+  exclude <- utils::glob2rx(exclude)
   files <- all_files
   for (pattern in exclude)
     files <- files[!grepl(pattern, files)]

--- a/docs/todo.Rmd
+++ b/docs/todo.Rmd
@@ -1,7 +1,6 @@
 
 ## JJ
  
-- Windows compatibility
 - Documentation on using the package
 
 ## Kevin


### PR DESCRIPTION
@kevinushey This appears to work fine for cross platform recursive file copying. We basically apply the include and exclude filters (which are defined using glob syntax) to the top level listing of files and then copy each of those top level items recursively into the target directory. 

FWIW this is the same code that I've been using in R Markdown websites.