### PR TITLE
Improve training time performance

### DIFF
--- a/inst/cloudml/setup.py
+++ b/inst/cloudml/setup.py
@@ -11,6 +11,7 @@ from setuptools.command.install import install
 #
 # First, note that there is no need to use the sudo command because the setup
 # script runs with appropriate access.
+#
 # Second, if apt-get tool is used then the first command needs to be "apt-get
 # update" so the tool refreshes itself and initializes links to download
 # repositories.  Without this initial step the other apt-get install commands
@@ -21,14 +22,20 @@ from setuptools.command.install import install
 # worker-startup log.
 
 CUSTOM_COMMANDS = [
-    # Update repositories and install R + dependencies
+    # Update repositories
     ["apt-get", "-qq", "-m", "-y", "update"],
-    ["apt-get", "-qq", "-m", "-y", "upgrade"],
+
+    # Upgrading packages could be useful but takes about 30-60s additional seconds
+    # ["apt-get", "-qq", "-m", "-y", "upgrade"],
+
+    # Install R + dependencies
     ["apt-get", "-qq", "-m", "-y", "install", "libcurl4-openssl-dev", "libxml2-dev", "libxslt-dev", "libssl-dev", "r-base", "r-base-dev"],
 
-    # These are here just because ml-engine doesn't provide TensorFlow 1.3 yet
-    ["pip", "install", "keras", "--upgrade"],
-    ["pip", "install", "tensorflow", "--upgrade"]
+    # ml-engine doesn't provide TensorFlow 1.3 yet but they could be potentially
+    # upgraded; however, we've found out some components (e.g. tfestimators) hang even
+    # under python when upgrading TensorFlow versions.
+    # ["pip", "install", "keras", "--upgrade"],
+    # ["pip", "install", "tensorflow", "--upgrade"]
 ]
 
 class CustomCommands(install):


### PR DESCRIPTION
Took a closer look at the ~3min training time:

~ 45s: Upgrade all System Packages
~ 30s: Install R System Dependencies
~ 45s: Upgrade TensorFlow
~ 10s: Initialize Python
~ 10s: Restore R packages from cache
~ 5s: Download train examples, train, upload results
~ 40s: Tearing down TensorFlow.

This PR proposes removing the following stages:

~ 45s: Upgrade all System Packages
~ 45s: Upgrade TensorFlow

Upgrading TensorFlow to use tfestimators uncovered a hang in both Python and R that CloudML needs to resolve. Upgrading all system packages shouldn't be required in most cases since we can rely on CloudML image having a recent version.

<img width="713" alt="screen shot 2017-11-27 at 4 49 23 pm" src="https://user-images.githubusercontent.com/3478847/33296906-fc58bc62-d392-11e7-9af9-dfc194b5400e.png">

to

<img width="714" alt="screen shot 2017-11-27 at 4 49 32 pm" src="https://user-images.githubusercontent.com/3478847/33296912-019a4bd2-d393-11e7-83a2-141c50880b26.png">
