### PR TITLE
Adds training and initial tuning doc

### DIFF
--- a/docs/articles/guides-training.html
+++ b/docs/articles/guides-training.html
@@ -5,7 +5,7 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Training Models • cloudml</title>
+<title>Training • cloudml</title>
 <!-- jquery --><script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script><!-- Bootstrap --><link href="https://maxcdn.bootstrapcdn.com/bootswatch/3.3.7/cosmo/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script><!-- Font Awesome icons --><link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-T8Gy5hrqNKT+hzMclPo118YTQO6cYprQmhrYwIiQ/3axmI1hQomh7Ud2hPOy8SP1" crossorigin="anonymous">
 <!-- pkgdown --><link href="../pkgdown.css" rel="stylesheet">
@@ -87,18 +87,135 @@
       </header><div class="row">
   <div class="col-md-9">
     <div class="page-header toc-ignore">
-      <h1>Training Models</h1>
+      <h1>Training</h1>
             
           </div>
 
     
     
 <div class="contents">
+<p>Cloud Machine Learning Engine enables you to easily run your TensorFlow training applications in the cloud. This page describes that capability and some of the key concepts you’ll need to understand to make the most of your model training.</p>
+<div id="how-training-works" class="section level2">
+<h2 class="hasAnchor">
+<a href="#how-training-works" class="anchor"></a>How training works</h2>
+<p>Your training application, implemented in R and TensorFlow, is the core of the training process. Cloud ML Engine runs your trainer on computing resources in the cloud. Here’s an overview of the process:</p>
+<ol style="list-style-type: decimal">
+<li>You create a TensorFlow application that defines your computation graph and trains your model. Cloud ML Engine has almost no specific requirements of your application during the training process, so you build it as you would to run locally in your development environment.</li>
+<li>You get your training and verification data into a source that Cloud ML Engine can access. This usually means putting it in Google Cloud Storage, Cloud Bigtable, or another Google Cloud Platform storage service associated with the same Google Cloud Platform project that you’re using for Cloud ML Engine.</li>
+<li>When your application is ready to run, it must be packaged and transferred to a Google Cloud Storage bucket that your project can access. This is automated with <code><a href="../reference/cloudml_train.html">cloudml_train()</a></code>.</li>
+<li>The Cloud ML Engine training service sets up resources for your job. It allocates one or more virtual machines (sometimes called training instances) based on your job configuration. Each training instance is set up by:
+<ul>
+<li>Applying the standard machine image for the version of Cloud ML Engine your job uses.</li>
+<li>Loading your trainer package and installing.</li>
+<li>Installing any additional packages that <code>packrat</code> detects.</li>
+</ul>
+</li>
+<li>The training service runs your trainer.</li>
+<li>You can get information about your running job in three ways:
+<ul>
+<li>On Stackdriver Logging.</li>
+<li>By requesting job details or running log streaming with the gcloud command-line tool.</li>
+<li>By programmatically making status requests to the training service using <code><a href="../reference/job_status.html">job_status()</a></code>.</li>
+</ul>
+</li>
+<li>When your trainer succeeds or encounters an unrecoverable error, Cloud ML Engine halts all job processes and cleans up the resources.</li>
+</ol>
+<p>If you run a distributed TensorFlow job with Cloud ML Engine, you’ll specify multiple machines (nodes) in a training cluster. The training service allocates the resources for the machine types you specify and performs step 4 above on each. Your running trainer on a given node is called a replica. In accordance with the distributed TensorFlow model, each replica in the training cluster is given a single role or task in distributed training:</p>
+<ul>
+<li>Exactly one replica is designated the master. This task manages the others and reports status for the job as a whole. It’s asserted in the previous list that the training service runs until “your trainer” succeeds or encounters an unrecoverable error. In the distributed case, it is the status of the master replica that signals the overall job status. If you are running a single-process job, the sole replica is the master for the job.</li>
+<li>One or more replicas may be designated as workers. These replicas do their portion of the work as you designate in your trainer.</li>
+<li>One or more replicas may be designated as parameter servers. These replicas coordinate shared model state between the workers.</li>
+</ul>
+</div>
+<div id="the-typical-case" class="section level2">
+<h2 class="hasAnchor">
+<a href="#the-typical-case" class="anchor"></a>The typical case</h2>
+<p>There are steps in the description above where you might assume that a machine learning service would intervene or control processing but where Cloud ML Engine doesn’t. The training service is designed to have as little an impact on your trainer as possible. This means you can focus on the TensorFlow code that makes the model you want instead of being confined by a rigid structure. Essentially this means that Cloud ML Engine doesn’t know or take interest in your application’s implementation.</p>
+<p>While it’s true that the training service imposes almost no restriction on your trainer’s architecture, that doesn’t mean that there isn’t any guidance to follow. Most machine learning trainers:</p>
+<ul>
+<li>Provide a way to get training data and evaluation data.</li>
+<li>Process data instances in batches.</li>
+<li>Use evaluation data to test the accuracy of the model (how often it predicts the right value).</li>
+<li>Provide a way to output checkpoints at intervals in the process to get a snapshot of the model’s progress.</li>
+<li>Provide a way to export the trained model when the trainer finishes.</li>
+</ul>
+</div>
+<div id="configuring-your-trainer" class="section level2">
+<h2 class="hasAnchor">
+<a href="#configuring-your-trainer" class="anchor"></a>Configuring your trainer</h2>
+<p>If you’ve never made a Python package before, this process can feel daunting. The good news is that you can rely on the gcloud command-line tool to do the heavy lifting for you. This section covers some of the specifics in more detail.</p>
+<div id="configuration" class="section level3">
+<h3 class="hasAnchor">
+<a href="#configuration" class="anchor"></a>Configuration</h3>
+<p>A <code>cloudml.yml</code> file must be specified in the current directory to configure: project, account, region, runtime and storage parameters used to configure Cloud ML while traininig.</p>
+<p>A simple configuration file looks as follows:</p>
+<div class="sourceCode"><pre class="sourceCode yml"><code class="sourceCode yaml"><span class="fu">gcloud:</span>
+  <span class="fu">project         :</span><span class="at"> </span><span class="st">"project-name"</span>
+  <span class="fu">account         :</span><span class="at"> </span><span class="st">"account@domain.com"</span>
+  <span class="fu">region          :</span><span class="at"> </span><span class="st">"us-central1"</span>
+  <span class="fu">runtime-version :</span><span class="at"> </span><span class="st">"1.2"</span>
 
+<span class="fu">cloudml:</span>
+  <span class="fu">storage         :</span><span class="at"> </span><span class="st">"gs://project-name/mnist"</span></code></pre></div>
+</div>
+<div id="scale-tier" class="section level3">
+<h3 class="hasAnchor">
+<a href="#scale-tier" class="anchor"></a>Scale tier</h3>
+<p>You must tell Cloud ML Engine the number and type of machines to run your training job on. To make the process easier, you can pick from a set of predefined cluster specifications called scale tiers.</p>
+<p>You can read more about the availaible tiers in <a href="https://cloud.google.com/ml-engine/docs/training-overview#scale_tier">Trainning Overview - Scale Tiers</a>.</p>
+</div>
+<div id="region" class="section level3">
+<h3 class="hasAnchor">
+<a href="#region" class="anchor"></a>Region</h3>
+<p>Google Cloud Platform uses <a href="https://cloud.google.com/compute/docs/regions-zones/regions-zones">zones and regions</a> to define the geographic locations of physical computing resources. Cloud ML Engine uses regions to designate its processing. When you run a training job, you specify the region that you want it to run in.</p>
+<p>If you store your training dataset on Google Cloud Storage, you should run your training job in the same region as the bucket you’re using. If you must run your job in a different region from your data bucket, your job may take longer.</p>
+<p>Additional configuration options can be found udner <a href="https://cloud.google.com/ml-engine/docs/training-overview">Trainning Overview</a>.</p>
+</div>
+<div id="dependencies" class="section level3">
+<h3 class="hasAnchor">
+<a href="#dependencies" class="anchor"></a>Dependencies</h3>
+<p>All package dependencies are automatically detected with a <a href="http://rstudio.github.io/packrat/">packrat</a> snapshot; this snapshot contains a list of packages and versions that, once training starts, is used to restore the state of the packages in each Cloud ML instance.</p>
+<div id="caching" class="section level4">
+<h4 class="hasAnchor">
+<a href="#caching" class="anchor"></a>Caching</h4>
+<p>Caching R package dependencies is enabled by default, this allows subsequent training runs to save several minutes of initialization time. The package cache is stored under <code>storage</code>; it can be disabled by setting this property to <code>false</code> in <code>cloudml.yml</code>:</p>
+<div class="sourceCode"><pre class="sourceCode yml"><code class="sourceCode yaml"><span class="fu">cloudml:</span>
+  <span class="fu">storage         :</span><span class="at"> </span><span class="st">"gs://project-name/mnist"</span>
+  <span class="fu">cache           :</span><span class="at"> false</span></code></pre></div>
+<p>The cache can also be shared among many projects by setting the <code>cache</code> path as follows:</p>
+<div class="sourceCode"><pre class="sourceCode yml"><code class="sourceCode yaml"><span class="fu">cloudml:</span>
+  <span class="fu">storage         :</span><span class="at"> </span><span class="st">"gs://project-name/mnist"</span>
+  <span class="fu">cache           :</span><span class="at"> </span><span class="st">"gs://project-name/cache"</span></code></pre></div>
+</div>
+</div>
+</div>
+<div id="deploying-your-trainer" class="section level2">
+<h2 class="hasAnchor">
+<a href="#deploying-your-trainer" class="anchor"></a>Deploying your trainer</h2>
+<p>To package and deploy youy job, simply run:</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">library</span>(cloudml)
+job &lt;-<span class="st"> </span><span class="kw"><a href="../reference/cloudml_train.html">cloudml_train</a></span>()</code></pre></div>
+<p>this will start the training process and return a job object you can use to collect the training resuts:</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw"><a href="../reference/job_collect.html">job_collect</a></span>(job)</code></pre></div>
+<p>To view the run results, you can use <code>tfruns</code> as follows:</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">library</span>(tfruns)
+<span class="kw"><a href="http://www.rdocumentation.org/packages/tfruns/topics/view_run">view_run</a></span>()</code></pre></div>
+<p>To understand additional job related operations, please consult the <a href="guides-jobs.html">Jobs Guide</a>.</p>
+</div>
 </div>
   </div>
 
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
+        <div id="tocnav">
+      <h2 class="hasAnchor">
+<a href="#tocnav" class="anchor"></a>Contents</h2>
+      <ul class="nav nav-pills nav-stacked">
+<li><a href="#how-training-works">How training works</a></li>
+      <li><a href="#the-typical-case">The typical case</a></li>
+      <li><a href="#configuring-your-trainer">Configuring your trainer</a></li>
+      <li><a href="#deploying-your-trainer">Deploying your trainer</a></li>
+      </ul>
+</div>
       </div>
 
 </div>

--- a/docs/articles/guides-tuning.html
+++ b/docs/articles/guides-tuning.html
@@ -5,7 +5,7 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Tuning Models • cloudml</title>
+<title>Tuning • cloudml</title>
 <!-- jquery --><script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script><!-- Bootstrap --><link href="https://maxcdn.bootstrapcdn.com/bootswatch/3.3.7/cosmo/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script><!-- Font Awesome icons --><link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-T8Gy5hrqNKT+hzMclPo118YTQO6cYprQmhrYwIiQ/3axmI1hQomh7Ud2hPOy8SP1" crossorigin="anonymous">
 <!-- pkgdown --><link href="../pkgdown.css" rel="stylesheet">
@@ -87,18 +87,72 @@
       </header><div class="row">
   <div class="col-md-9">
     <div class="page-header toc-ignore">
-      <h1>Tuning Models</h1>
+      <h1>Tuning</h1>
             
           </div>
 
     
     
 <div class="contents">
-
+<p>Hyperparameter tuning is the automated model enhancer provided by Cloud Machine Learning Engine. Hyperparameter tuning takes advantage of the processing infrastructure of Google Cloud Platform to test different hyperparameter configurations when training your model. It can give you optimized values for hyperparameters, which maximizes your model’s predictive accuracy.</p>
+<div id="whats-a-hyperparameter" class="section level2">
+<h2 class="hasAnchor">
+<a href="#whats-a-hyperparameter" class="anchor"></a>What’s a hyperparameter?</h2>
+<p>If you’re new to machine learning, you may have never encountered the term hyperparameters before. Your trainer handles three categories of data as it trains your model:</p>
+<ul>
+<li>Your input data (also called training data) is a collection of individual records (instances) containing the features important to your machine learning problem. This data is used during training to configure your model to accurately make predictions about new instances of similar data. However, the actual values in your input data never directly become part of your model.</li>
+<li>Your model’s parameters are the variables that your chosen machine learning technique uses to adjust to your data. For example, a deep neural network (DNN) is composed of processing nodes (neurons), each with an operation performed on data as it travels through the network. When your DNN is trained, each node has a weight value that tells your model how much impact it has on the final prediction. Those weights are an example of your model’s parameters. In many ways, your model’s parameters are the model—they are what distinguishes your particular model from other models of the same type working on similar data.</li>
+<li>If model parameters are variables that get adjusted by training with existing data, your hyperparameters are the variables about the training process itself. For example, part of setting up a deep neural network is deciding how many “hidden” layers of nodes to use between the input layer and the output layer, as well as how many nodes each layer should use. These variables are not directly related to the training data at all. They are configuration variables. Another difference is that parameters change during a training job, while the hyperparameters are usually constant during a job. Your model parameters are optimized (you could say “tuned”) by the training process: you run data through the operations of the model, compare the resulting prediction with the actual value for each data instance, evaluate the accuracy, and adjust until you find the best values. Hyperparameters are similarly tuned by running your whole training job, looking at the aggregate accuracy, and adjusting. In both cases you are modifying the composition of your model in an effort to find the best combination to handle your problem.</li>
+</ul>
+<p>Without an automated technology like Cloud ML Engine hyperparameter tuning, you need to make manual adjustments to the hyperparameters over the course of many training runs to arrive at the optimal values. Hyperparameter tuning makes the process of determining the best hyperparameter settings easier and less tedious.</p>
+</div>
+<div id="how-it-works" class="section level2">
+<h2 class="hasAnchor">
+<a href="#how-it-works" class="anchor"></a>How it works</h2>
+<p>Hyperparameter tuning works by running multiple trials in a single training job. Each trial is a complete execution of your training application with values for your chosen hyperparameters set within limits you specify. The Cloud ML Engine training service keeps track of the results of each trial and makes adjustments for subsequent trials. When the job is finished, you can get a summary of all the trials along with the most effective configuration of values according to the criteria you specify.</p>
+<p>Hyperparameter tuning requires more explicit communication between the Cloud ML Engine training service and your training application. You define all the information that your model needs in your training application. The best way to think about this interaction is that you define the hyperparameters (variables) that you want to adjust and you define a target value.</p>
+</div>
+<div id="what-it-optimizes" class="section level2">
+<h2 class="hasAnchor">
+<a href="#what-it-optimizes" class="anchor"></a>What it optimizes</h2>
+<p>Hyperparameter tuning optimizes a single target variable (also called the hyperparameter metric) that you specify. The accuracy of the model, as calculated from an evaluation pass, is a common metric. The metric must be a numeric value, and you can specify whether you want to tune your model to maximize or minimize your metric.</p>
+<p>When you start a job with hyperparameter tuning, you establish the name of your hyperparameter metric. This is the name you assign to the scalar summary that you add to your trainer. You can use a custom name if you want, or you can use the default name of <code>training/hptuning/metric</code>. The only functional difference is that if you use a custom name you must set the <code>hyperparameterMetricTag</code> value in <code>hyperparam.yml</code> to match your chosen name.</p>
+</div>
+<div id="example" class="section level2">
+<h2 class="hasAnchor">
+<a href="#example" class="anchor"></a>Example</h2>
+<p>Tuning your model’s parameters can be easily accomplished using a <code>hypertune.yml</code> file which specifies how to parameterized your model across multiple runs. In addition, the model requires <a href="guides-tunning.html">training</a> to be configured correctly.</p>
+<p>For MNIST, <code>hypertune.yml</code> can look like:</p>
+<div class="sourceCode"><pre class="sourceCode yml"><code class="sourceCode yaml"><span class="fu">trainingInput:</span>
+  <span class="fu">hyperparameters:</span>
+    <span class="fu">goal:</span><span class="at"> MAXIMIZE</span>
+    <span class="fu">hyperparameterMetricTag:</span><span class="at"> accuracy</span>
+    <span class="fu">maxTrials:</span><span class="at"> 2</span>
+    <span class="fu">maxParallelTrials:</span><span class="at"> 2</span>
+    <span class="fu">params:</span>
+      <span class="kw">-</span> <span class="fu">parameterName:</span><span class="at"> gradient-descent-optimizer</span>
+        <span class="fu">type:</span><span class="at"> DOUBLE</span>
+        <span class="fu">minValue:</span><span class="at"> 0.4</span>
+        <span class="fu">maxValue:</span><span class="at"> 0.5</span>
+        <span class="fu">scaleType:</span><span class="at"> UNIT_LINEAR_SCALE</span></code></pre></div>
+<p>Then you can tune and collect the optimal model as follows:</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">job &lt;-<span class="st"> </span><span class="kw"><a href="../reference/cloudml_tune.html">cloudml_tune</a></span>()
+<span class="kw"><a href="../reference/job_collect.html">job_collect</a></span>(job)</code></pre></div>
+</div>
 </div>
   </div>
 
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
+        <div id="tocnav">
+      <h2 class="hasAnchor">
+<a href="#tocnav" class="anchor"></a>Contents</h2>
+      <ul class="nav nav-pills nav-stacked">
+<li><a href="#whats-a-hyperparameter">What’s a hyperparameter?</a></li>
+      <li><a href="#how-it-works">How it works</a></li>
+      <li><a href="#what-it-optimizes">What it optimizes</a></li>
+      <li><a href="#example">Example</a></li>
+      </ul>
+</div>
       </div>
 
 </div>

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -121,8 +121,8 @@
         <li><a href="examples-keras.html">Keras Example</a></li>
         <li><a href="examples-mnist.html">MNIST Example</a></li>
         <li><a href="guides-jobs.html">Managing Jobs</a></li>
-        <li><a href="guides-training.html">Training Models</a></li>
-        <li><a href="guides-tuning.html">Tuning Models</a></li>
+        <li><a href="guides-training.html">Training</a></li>
+        <li><a href="guides-tuning.html">Tuning</a></li>
       </ul>
     </div>
   </div>

--- a/man/job_cancel.Rd
+++ b/man/job_cancel.Rd
@@ -18,3 +18,4 @@ Other job management: \code{\link{job_collect_async}},
   \code{\link{job_list}}, \code{\link{job_status}},
   \code{\link{job_stream}}
 }
+\concept{job management}

--- a/man/job_collect.Rd
+++ b/man/job_collect.Rd
@@ -23,3 +23,4 @@ Other job management: \code{\link{job_cancel}},
   \code{\link{job_describe}}, \code{\link{job_list}},
   \code{\link{job_status}}, \code{\link{job_stream}}
 }
+\concept{job management}

--- a/man/job_collect_async.Rd
+++ b/man/job_collect_async.Rd
@@ -28,3 +28,4 @@ Other job management: \code{\link{job_cancel}},
   \code{\link{job_list}}, \code{\link{job_status}},
   \code{\link{job_stream}}
 }
+\concept{job management}

--- a/man/job_describe.Rd
+++ b/man/job_describe.Rd
@@ -18,3 +18,4 @@ Other job management: \code{\link{job_cancel}},
   \code{\link{job_collect}}, \code{\link{job_list}},
   \code{\link{job_status}}, \code{\link{job_stream}}
 }
+\concept{job management}

--- a/man/job_list.Rd
+++ b/man/job_list.Rd
@@ -34,3 +34,4 @@ Other job management: \code{\link{job_cancel}},
   \code{\link{job_collect}}, \code{\link{job_describe}},
   \code{\link{job_status}}, \code{\link{job_stream}}
 }
+\concept{job management}

--- a/man/job_status.Rd
+++ b/man/job_status.Rd
@@ -18,3 +18,4 @@ Other job management: \code{\link{job_cancel}},
   \code{\link{job_collect}}, \code{\link{job_describe}},
   \code{\link{job_list}}, \code{\link{job_stream}}
 }
+\concept{job management}

--- a/man/job_stream.Rd
+++ b/man/job_stream.Rd
@@ -26,3 +26,4 @@ Other job management: \code{\link{job_cancel}},
   \code{\link{job_collect}}, \code{\link{job_describe}},
   \code{\link{job_list}}, \code{\link{job_status}}
 }
+\concept{job management}

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,6 +1,6 @@
 library(testthat)
 library(cloudml)
 
-if (identical(Sys.getenv("NOT_CRAN"), "true")) {
+if (identical(Sys.getenv("NOT_CRAN"), "true") && nchar(Sys.getenv("GCLOUD_ACCOUNT_FILE")) > 0) {
   test_check("cloudml")
 }

--- a/tests/testthat/helper-initialize.R
+++ b/tests/testthat/helper-initialize.R
@@ -18,23 +18,29 @@ sysenv_file <- function(name, destination) {
   }
 }
 
-cloudml:::gcloud_install()
-
-options(repos = c(CRAN = "http://cran.rstudio.com"))
-
-account_file <- tempfile(fileext = ".json")
-sysenv_file("GCLOUD_ACCOUNT_FILE", account_file)
-
-if (!is.null(account_file)) {
-  gcloud_exec(
-    "auth",
-    "activate-service-account",
-    paste(
-      "--key-file",
-      account_file,
-      sep = "="
-    )
-  )
+cloudml_tests_configured <- function() {
+  nchar(Sys.getenv("GCLOUD_ACCOUNT_FILE")) > 0
 }
 
-sysenv_file("GCLOUD_CONFIG_FILE", "cloudml.yml")
+if (cloudml_tests_configured()) {
+  cloudml:::gcloud_install()
+
+  options(repos = c(CRAN = "http://cran.rstudio.com"))
+
+  account_file <- tempfile(fileext = ".json")
+  sysenv_file("GCLOUD_ACCOUNT_FILE", account_file)
+
+  if (!is.null(account_file)) {
+    gcloud_exec(
+      "auth",
+      "activate-service-account",
+      paste(
+        "--key-file",
+        account_file,
+        sep = "="
+      )
+    )
+  }
+
+  sysenv_file("GCLOUD_CONFIG_FILE", "cloudml.yml")
+}

--- a/tests/testthat/test-jobs.R
+++ b/tests/testthat/test-jobs.R
@@ -1,6 +1,8 @@
 context("jobs")
 
 test_that("job_list() succeeds", {
+  if (!cloudml_tests_configured()) return()
+
   all_jobs <- job_list()
   expect_gte(nrow(all_jobs), 0)
 })

--- a/tests/testthat/test-train.R
+++ b/tests/testthat/test-train.R
@@ -1,6 +1,8 @@
 context("train")
 
 test_that("cloudml_train() can train and collect savedmodel", {
+  if (!cloudml_tests_configured()) return()
+
   config_yml <- system.file("examples/mnist/cloudml.yml", package = "cloudml")
   file.copy("cloudml.yml", config_yml, overwrite = TRUE)
 

--- a/vignettes/guides-training.Rmd
+++ b/vignettes/guides-training.Rmd
@@ -1,6 +1,133 @@
 ---
-title: "Training Models"
+title: "Training"
 output: 
   html_document:
     toc_depth: 3
 ---
+
+Cloud Machine Learning Engine enables you to easily run your TensorFlow training applications in the cloud. This page describes that capability and some of the key concepts you'll need to understand to make the most of your model training.
+
+## How training works
+
+Your training application, implemented in R and TensorFlow, is the core of the training process. Cloud ML Engine runs your trainer on computing resources in the cloud. Here's an overview of the process:
+
+1. You create a TensorFlow application that defines your computation graph and trains your model. Cloud ML Engine has almost no specific requirements of your application during the training process, so you build it as you would to run locally in your development environment.
+2. You get your training and verification data into a source that Cloud ML Engine can access. This usually means putting it in Google Cloud Storage, Cloud Bigtable, or another Google Cloud Platform storage service associated with the same Google Cloud Platform project that you're using for Cloud ML Engine.
+3. When your application is ready to run, it must be packaged and transferred to a Google Cloud Storage bucket that your project can access. This is automated with `cloudml_train()`.
+4. The Cloud ML Engine training service sets up resources for your job. It allocates one or more virtual machines (sometimes called training instances) based on your job configuration. Each training instance is set up by:
+    - Applying the standard machine image for the version of Cloud ML Engine your job uses.
+    - Loading your trainer package and installing.
+    - Installing any additional packages that `packrat` detects.
+5. The training service runs your trainer.
+6. You can get information about your running job in three ways:
+    - On Stackdriver Logging.
+    - By requesting job details or running log streaming with the gcloud command-line tool.
+    - By programmatically making status requests to the training service using `job_status()`.
+7. When your trainer succeeds or encounters an unrecoverable error, Cloud ML Engine halts all job processes and cleans up the resources.
+
+If you run a distributed TensorFlow job with Cloud ML Engine, you'll specify multiple machines (nodes) in a training cluster. The training service allocates the resources for the machine types you specify and performs step 4 above on each. Your running trainer on a given node is called a replica. In accordance with the distributed TensorFlow model, each replica in the training cluster is given a single role or task in distributed training:
+
+- Exactly one replica is designated the master. This task manages the others and reports status for the job as a whole. It's asserted in the previous list that the training service runs until "your trainer" succeeds or encounters an unrecoverable error. In the distributed case, it is the status of the master replica that signals the overall job status. If you are running a single-process job, the sole replica is the master for the job.
+- One or more replicas may be designated as workers. These replicas do their portion of the work as you designate in your trainer.
+- One or more replicas may be designated as parameter servers. These replicas coordinate shared model state between the workers.
+
+## The typical case
+
+There are steps in the description above where you might assume that a machine learning service would intervene or control processing but where Cloud ML Engine doesn't. The training service is designed to have as little an impact on your trainer as possible. This means you can focus on the TensorFlow code that makes the model you want instead of being confined by a rigid structure. Essentially this means that Cloud ML Engine doesn't know or take interest in your application's implementation.
+
+While it's true that the training service imposes almost no restriction on your trainer's architecture, that doesn't mean that there isn't any guidance to follow. Most machine learning trainers:
+
+- Provide a way to get training data and evaluation data.
+- Process data instances in batches.
+- Use evaluation data to test the accuracy of the model (how often it predicts the right value).
+- Provide a way to output checkpoints at intervals in the process to get a snapshot of the model's progress.
+- Provide a way to export the trained model when the trainer finishes.
+
+## Configuring your trainer
+
+If you've never made a Python package before, this process can feel daunting. The good news is that you can rely on the gcloud command-line tool to do the heavy lifting for you. This section covers some of the specifics in more detail.
+
+### Configuration
+
+A `cloudml.yml` file must be specified in the current directory to configure: project,
+account, region, runtime and storage parameters used to configure Cloud ML while
+traininig. 
+
+A simple configuration file looks as follows:
+
+```{yml}
+gcloud:
+  project         : "project-name"
+  account         : "account@domain.com"
+  region          : "us-central1"
+  runtime-version : "1.2"
+
+cloudml:
+  storage         : "gs://project-name/mnist"
+```
+
+### Scale tier
+
+You must tell Cloud ML Engine the number and type of machines to run your training job on. To make the process easier, you can pick from a set of predefined cluster specifications called scale tiers.
+
+You can read more about the availaible tiers in [Trainning Overview - Scale Tiers](https://cloud.google.com/ml-engine/docs/training-overview#scale_tier).
+
+### Region
+
+Google Cloud Platform uses [zones and regions](https://cloud.google.com/compute/docs/regions-zones/regions-zones) to define the geographic locations of physical computing resources. Cloud ML Engine uses regions to designate its processing. When you run a training job, you specify the region that you want it to run in.
+
+If you store your training dataset on Google Cloud Storage, you should run your training job in the same region as the bucket you're using. If you must run your job in a different region from your data bucket, your job may take longer.
+
+Additional configuration options can be found udner [Trainning Overview](https://cloud.google.com/ml-engine/docs/training-overview).
+
+### Dependencies
+
+All package dependencies are automatically detected with a [packrat](http://rstudio.github.io/packrat/) snapshot; this snapshot contains
+a list of packages and versions that, once training starts, is used to restore
+the state of the packages in each Cloud ML instance.
+
+#### Caching
+
+Caching R package dependencies is enabled by default, this allows subsequent training runs
+to save several minutes of initialization time. The package cache is stored under `storage`;
+it can be disabled by setting this property to `false` in `cloudml.yml`:
+
+```{yml}
+cloudml:
+  storage         : "gs://project-name/mnist"
+  cache           : false
+```
+
+The cache can also be shared among many projects by setting the `cache` path as
+follows:
+
+```{yml}
+cloudml:
+  storage         : "gs://project-name/mnist"
+  cache           : "gs://project-name/cache"
+```
+
+## Deploying your trainer
+
+To package and deploy youy job, simply run:
+
+```{r eval=F}
+library(cloudml)
+job <- cloudml_train()
+```
+
+this will start the training process and return a job object you can use to collect
+the training resuts:
+
+```{r eval=F}
+job_collect(job)
+```
+
+To view the run results, you can use `tfruns` as follows:
+
+```{r eval=F}
+library(tfruns)
+view_run()
+```
+
+To understand additional job related operations, please consult the [Jobs Guide](guides-jobs.html).

--- a/vignettes/guides-tuning.Rmd
+++ b/vignettes/guides-tuning.Rmd
@@ -1,6 +1,62 @@
 ---
-title: "Tuning Models"
+title: "Tuning"
 output: 
   html_document:
     toc_depth: 3
 ---
+
+Hyperparameter tuning is the automated model enhancer provided by Cloud Machine Learning Engine. Hyperparameter tuning takes advantage of the processing infrastructure of Google Cloud Platform to test different hyperparameter configurations when training your model. It can give you optimized values for hyperparameters, which maximizes your model's predictive accuracy.
+
+## What's a hyperparameter?
+
+If you're new to machine learning, you may have never encountered the term hyperparameters before. Your trainer handles three categories of data as it trains your model:
+
+- Your input data (also called training data) is a collection of individual records (instances) containing the features important to your machine learning problem. This data is used during training to configure your model to accurately make predictions about new instances of similar data. However, the actual values in your input data never directly become part of your model.
+- Your model's parameters are the variables that your chosen machine learning technique uses to adjust to your data. For example, a deep neural network (DNN) is composed of processing nodes (neurons), each with an operation performed on data as it travels through the network. When your DNN is trained, each node has a weight value that tells your model how much impact it has on the final prediction. Those weights are an example of your model's parameters. In many ways, your model's parameters are the model—they are what distinguishes your particular model from other models of the same type working on similar data.
+- If model parameters are variables that get adjusted by training with existing data, your hyperparameters are the variables about the training process itself. For example, part of setting up a deep neural network is deciding how many "hidden" layers of nodes to use between the input layer and the output layer, as well as how many nodes each layer should use. These variables are not directly related to the training data at all. They are configuration variables. Another difference is that parameters change during a training job, while the hyperparameters are usually constant during a job.
+Your model parameters are optimized (you could say "tuned") by the training process: you run data through the operations of the model, compare the resulting prediction with the actual value for each data instance, evaluate the accuracy, and adjust until you find the best values. Hyperparameters are similarly tuned by running your whole training job, looking at the aggregate accuracy, and adjusting. In both cases you are modifying the composition of your model in an effort to find the best combination to handle your problem.
+
+Without an automated technology like Cloud ML Engine hyperparameter tuning, you need to make manual adjustments to the hyperparameters over the course of many training runs to arrive at the optimal values. Hyperparameter tuning makes the process of determining the best hyperparameter settings easier and less tedious.
+
+## How it works
+
+Hyperparameter tuning works by running multiple trials in a single training job. Each trial is a complete execution of your training application with values for your chosen hyperparameters set within limits you specify. The Cloud ML Engine training service keeps track of the results of each trial and makes adjustments for subsequent trials. When the job is finished, you can get a summary of all the trials along with the most effective configuration of values according to the criteria you specify.
+
+Hyperparameter tuning requires more explicit communication between the Cloud ML Engine training service and your training application. You define all the information that your model needs in your training application. The best way to think about this interaction is that you define the hyperparameters (variables) that you want to adjust and you define a target value.
+
+## What it optimizes
+
+Hyperparameter tuning optimizes a single target variable (also called the hyperparameter metric) that you specify. The accuracy of the model, as calculated from an evaluation pass, is a common metric. The metric must be a numeric value, and you can specify whether you want to tune your model to maximize or minimize your metric.
+
+When you start a job with hyperparameter tuning, you establish the name of your hyperparameter metric. This is the name you assign to the scalar summary that you add to your trainer. You can use a custom name if you want, or you can use the default name of `training/hptuning/metric`. The only functional difference is that if you use a custom name you must set the `hyperparameterMetricTag` value in
+`hyperparam.yml` to match your chosen name.
+
+## Example
+
+Tuning your model's parameters can be easily accomplished using a `hypertune.yml` file
+which specifies how to parameterized your model across multiple runs. In addition,
+the model requires [training](guides-tunning.html) to be configured correctly.
+
+For MNIST, `hypertune.yml` can look like:
+
+```{yml}
+trainingInput:
+  hyperparameters:
+    goal: MAXIMIZE
+    hyperparameterMetricTag: accuracy
+    maxTrials: 2
+    maxParallelTrials: 2
+    params:
+      - parameterName: gradient-descent-optimizer
+        type: DOUBLE
+        minValue: 0.4
+        maxValue: 0.5
+        scaleType: UNIT_LINEAR_SCALE
+```
+
+Then you can tune and collect the optimal model as follows:
+
+```{r eval=FALSE}
+job <- cloudml_tune()
+job_collect(job)
+```


### PR DESCRIPTION
Adds training and initial tuning doc,  articles mostly based on Google cloudml docs.

@jjallaire Merging PR since it's easier to address feedback over the site, new docs:

[https://rstudio.github.io/cloudml/articles/guides-training.html](https://rstudio.github.io/cloudml/articles/guides-training.html)
[https://rstudio.github.io/cloudml/articles/guides-tuning.html](https://rstudio.github.io/cloudml/articles/guides-tuning.html)