### PR TITLE
Move runtime-version field into cloudml section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 # R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
 
 language: r
+dist: trusty
 sudo: false
 cache: packages
 script:

--- a/R/config.R
+++ b/R/config.R
@@ -28,11 +28,11 @@ cloudml_init <- function() {
     gcloud = list(
       project = "project-name",
       account = "account@domain.com",
-      region  = "us-central1",
-      "runtime-version" = "1.2"
+      region  = "us-central1"
     ),
     cloudml = list(
-      storage = "gs://project-name/mnist"
+      storage = "gs://project-name/mnist",
+      "runtime-version" = "1.2"
     )
   )
 

--- a/R/gcloud-install.R
+++ b/R/gcloud-install.R
@@ -57,7 +57,7 @@ gcloud_path_default <- function() {
 #'
 #' @importFrom utils untar
 gcloud_install <- function(version = "180.0.1") {
-  if (dir.exists(gcloud_path_default())) {
+  if (file_test("-d", gcloud_path_default())) {
     message("SDK already installed.")
     return(invisible(NULL))
   }
@@ -77,7 +77,7 @@ gcloud_install <- function(version = "180.0.1") {
   download_dir <- tempdir()
   download_file <- file.path(download_dir, cloudsdk_tar)
 
-  if (!dir.exists(download_dir)) dir.create(download_dir)
+  if (!file_test("-d", download_dir)) dir.create(download_dir)
 
   download.file(
     file.path(cloudsdk_url, cloudsdk_tar),

--- a/R/jobs.R
+++ b/R/jobs.R
@@ -58,7 +58,7 @@ cloudml_train <- function(application = getwd(),
                 ("--package-path=%s", basename(directory))
                 ("--module-name=%s.cloudml.deploy", basename(directory))
                 ("--staging-bucket=%s", gcloud[["staging-bucket"]])
-                ("--runtime-version=%s", gcloud[["runtime-version"]])
+                ("--runtime-version=%s", cloudml[["runtime-version"]])
                 ("--region=%s", gcloud[["region"]])
                 ("--config=%s/%s", basename(application), overlay$hypertune)
                 ("--")

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Application deployment is configured through the use of a top-level [YAML](http:
 
 ``` r
 library(cloudml)
-cloudml_create_config()
+cloudml_init()
 ```
 
 Then modify this default file with the appropiate `project`, `account`, `region` and `sotage`:
@@ -51,10 +51,10 @@ gcloud:
   project         : "project-name"
   account         : "account@domain.com"
   region          : "us-central1"
-  runtime-version : "1.2"
 
 cloudml:
   storage         : "gs://project-name/mnist"
+  runtime-version : "1.2"
 ```
 
 The `gcloud` key is used for configuration specific to the Google Cloud SDK, and so contains items relevant to how applications are deployed.
@@ -63,13 +63,13 @@ The `gcloud` key is used for configuration specific to the Google Cloud SDK, and
 
 -   Instances provisioned for training will be launched in the region specified by `region`,
 
--   The TensorFlow version to be used during training is configured using the `runtime-version` field.
-
 The `storage` field in the `cloudml` section indicates where various artefacts used during provisioning and training are stored. Some useful paths to know:
 
 -   `<storage>/staging`: applications will be 'staged' in this directory; that is, your deployed application will be uploaded and built in this location;
 
 -   `<storage>/runs/<timestamp>`: training outputs will be copied to this directory.
+
+The TensorFlow version to be used during training is configured using the `runtime-version` field within the `cloudml` section.
 
 Training
 --------

--- a/inst/cloudml/cloudml/deploy.R
+++ b/inst/cloudml/cloudml/deploy.R
@@ -115,7 +115,7 @@ retrieve_cached_packages <- function() {
   if (identical(cache, FALSE)) return()
 
   compressed <- file.path(tempdir(), "cache/")
-  if (!dir.exists(compressed)) dir.create(compressed, recursive = TRUE)
+  if (!file_test("-d", compressed)) dir.create(compressed, recursive = TRUE)
 
   remote_path <- file.path(cache, "*")
 
@@ -127,7 +127,7 @@ retrieve_cached_packages <- function() {
     target_package <- strsplit(basename(tar_file), "\\.")[[1]][[1]]
     target_path <- file.path(target, target_package)
 
-    if (!dir.exists(target_path)) dir.create(target_path, recursive = TRUE)
+    if (!file_test("-d", target_path)) dir.create(target_path, recursive = TRUE)
 
     message(paste0("Restoring package from ", tar_file, " cache into ", target_path, "."))
     system2("tar", c("-xf", tar_file, "-C", target_path))

--- a/inst/examples/census/cloudml.yml
+++ b/inst/examples/census/cloudml.yml
@@ -2,8 +2,8 @@ gcloud:
   project         : "project-name"
   account         : "account@domain.com"
   region          : "us-central1"
-  runtime-version : "1.2"
 
 cloudml:
   storage         : "gs://project-name/census"
   cache           : "gs://project-name/cache"
+  runtime-version : "1.2"

--- a/inst/examples/diagnostics/cloudml.yml
+++ b/inst/examples/diagnostics/cloudml.yml
@@ -2,4 +2,6 @@ gcloud:
   project         : "rstudio-cloudml"
   account         : "kevin@rstudio.com"
   region          : "us-central1"
+
+cloudml:
   runtime-version : "1.2"

--- a/inst/examples/mnist/cloudml.yml
+++ b/inst/examples/mnist/cloudml.yml
@@ -2,7 +2,7 @@ gcloud:
   project         : "rstudio-cloudml"
   account         : "javier@rstudio.com"
   region          : "us-east1"
-  runtime-version : "1.2"
 
 cloudml:
   storage         : "gs://rstudio-cloudml/mnist"
+  runtime-version : "1.2"

--- a/inst/examples/mtcars/r/cloudml.yml
+++ b/inst/examples/mtcars/r/cloudml.yml
@@ -2,8 +2,8 @@ gcloud:
   project         : "project-name"
   account         : "account@domain.com"
   region          : "us-central1"
-  runtime-version : "1.2"
 
 cloudml:
   storage         : "gs://project-name/mtcars"
   cache           : "gs://project-name/cache"
+  runtime-version : "1.2"

--- a/tests/testthat/test-train.R
+++ b/tests/testthat/test-train.R
@@ -20,7 +20,7 @@ test_that("cloudml_train() can train and collect savedmodel", {
 
   collected <- job_collect(job)
 
-  expect_true(dir.exists("runs"))
+  expect_true(file_test("-d", "runs"))
 
   saved_model <- dir(
     "runs",


### PR DESCRIPTION
I believe that this field is specific to CloudML rather than a more general property of the GCloud config. Let me know if this makes sense to you.