### PR TITLE
support for training flags

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Description: Interface to the Google Cloud Machine Learning Platform which provi
   support to train and tune machine learning models at scale under Cloud ML.
 Depends:
   R (>= 3.2.0), 
-  tfruns (>= 1.0.0.9004)
+  tfruns (>= 1.0.0.9005)
 Imports:
   jsonlite,
   packrat,

--- a/R/jobs.R
+++ b/R/jobs.R
@@ -4,10 +4,18 @@
 #' Upload a TensorFlow application to Google Cloud, and use that application to
 #' train a model.
 #'
+#' @inheritParams tfruns::training_run
+#'
 #' @param file File to be used as entrypoint for training.
 #'
 #' @param config The name of the configuration to be used. Defaults to the
 #'   `"cloudml"` configuration.
+#'
+#' @param hypertune
+#'   Path to a YAML file, defining how hyperparameters should
+#'   be tuned. See
+#'   https://cloud.google.com/ml/reference/rest/v1/projects.jobs
+#'   for more details.
 #'
 #' @param collect Collect job output after submission. Defaults to "ask" which
 #'   will prompt within interactive environments. Within versions of RStudio
@@ -21,9 +29,10 @@
 #'
 #' @export
 cloudml_train <- function(file = "train.R",
-                          config      = "cloudml",
-                          collect = "ask",
-                          ...)
+                          config = "cloudml",
+                          flags = NULL,
+                          hypertune = NULL,
+                          collect = "ask")
 {
   message("Submitting training job to CloudML...")
 
@@ -33,13 +42,12 @@ cloudml_train <- function(file = "train.R",
 
   # prepare application for deployment
   id <- unique_job_name(config)
-  overlay <- list(...)
   deployment <- scope_deployment(
     id = id,
     application = application,
     context = "cloudml",
     config = config,
-    overlay = overlay,
+    overlay = flags,
     entrypoint = entrypoint
   )
 
@@ -84,7 +92,7 @@ cloudml_train <- function(file = "train.R",
                 ("--staging-bucket=%s", gcloud[["staging-bucket"]])
                 ("--runtime-version=%s", cloudml_version)
                 ("--region=%s", gcloud[["region"]])
-                ("--config=%s/%s", basename(application), overlay$hypertune)
+                ("--config=%s/%s", basename(application), hypertune)
                 ("--")
                 ("Rscript"))
 

--- a/R/tune.R
+++ b/R/tune.R
@@ -1,28 +1,23 @@
 #' Tune hyperparameters on Cloud ML
 #'
 #' @inheritParams cloudml_train
-#' @param hypertune
-#'   Path to a YAML file, defining how hyperparameters should
-#'   be tuned. See
-#'   https://cloud.google.com/ml/reference/rest/v1/projects.jobs
-#'   for more details.
 #'
 #' @export
 cloudml_tune <- function(file = "train.R",
                          config = "cloudml",
-                         hypertune = "hypertune.yml",
-                         ...)
+                         flags = NULL,
+                         hypertune = "hypertune.yml")
 {
   # validate hyperparameters path
   application <- getwd()
   if (!file.exists(file.path(application, hypertune))) {
-    fmt <- "no configuration file exists at path '%s'"
+    fmt <- "no tuning configuration file exists at path '%s'"
     stopf(fmt, file.path(application, hypertune))
   }
 
   # delegate to cloudml_train
   cloudml_train(file = file,
                 config = config,
-                hypertune = hypertune,
-                ...)
+                flags = flags,
+                hypertune = hypertune)
 }

--- a/inst/cloudml/cloudml/deploy.py
+++ b/inst/cloudml/cloudml/deploy.py
@@ -16,7 +16,7 @@ os.chdir(os.path.dirname(path))
 # Run 'Rscript' with this entrypoint. We don't forward command line arguments,
 # as 'gcloud' will append a '--job-dir' argument (when specified) which can
 # confuse the tfruns flags system.
-commands = [sys.argv[1], deploy] + sys.argv[2:]
+commands = [sys.argv[1], deploy] + ["--args"] + sys.argv[2:]
 
 process = subprocess.Popen(
   commands,

--- a/man/cloudml_train.Rd
+++ b/man/cloudml_train.Rd
@@ -4,13 +4,22 @@
 \alias{cloudml_train}
 \title{Train a model using Cloud ML}
 \usage{
-cloudml_train(file = "train.R", config = "cloudml", collect = "ask", ...)
+cloudml_train(file = "train.R", config = "cloudml", flags = NULL,
+  hypertune = NULL, collect = "ask")
 }
 \arguments{
 \item{file}{File to be used as entrypoint for training.}
 
 \item{config}{The name of the configuration to be used. Defaults to the
 \code{"cloudml"} configuration.}
+
+\item{flags}{Named list with flag values (see \code{\link[=flags]{flags()}}) or path
+to YAML file containing flag values.}
+
+\item{hypertune}{Path to a YAML file, defining how hyperparameters should
+be tuned. See
+https://cloud.google.com/ml/reference/rest/v1/projects.jobs
+for more details.}
 
 \item{collect}{Collect job output after submission. Defaults to "ask" which
 will prompt within interactive environments. Within versions of RStudio

--- a/man/cloudml_tune.Rd
+++ b/man/cloudml_tune.Rd
@@ -4,8 +4,8 @@
 \alias{cloudml_tune}
 \title{Tune hyperparameters on Cloud ML}
 \usage{
-cloudml_tune(file = "train.R", config = "cloudml",
-  hypertune = "hypertune.yml", ...)
+cloudml_tune(file = "train.R", config = "cloudml", flags = NULL,
+  hypertune = "hypertune.yml")
 }
 \arguments{
 \item{file}{File to be used as entrypoint for training.}
@@ -13,13 +13,13 @@ cloudml_tune(file = "train.R", config = "cloudml",
 \item{config}{The name of the configuration to be used. Defaults to the
 \code{"cloudml"} configuration.}
 
+\item{flags}{Named list with flag values (see \code{\link[=flags]{flags()}}) or path
+to YAML file containing flag values.}
+
 \item{hypertune}{Path to a YAML file, defining how hyperparameters should
 be tuned. See
 https://cloud.google.com/ml/reference/rest/v1/projects.jobs
 for more details.}
-
-\item{...}{Named arguments, used to supply runtime configuration settings to
-your TensorFlow application.}
 }
 \description{
 Tune hyperparameters on Cloud ML


### PR DESCRIPTION
As of now training flags don't work due to tfruns barfing on the `--job-dir` parameter. I am attempting to get this working again. Step 1 is this change to tfruns:

https://github.com/rstudio/tfruns/commit/8d79cda94d93f4c47887e46e1992d48f756a6342

The next piece is actually inserting `--args` in the call to Rscript so `--job-dir` is ignored:

https://github.com/rstudio/cloudml/commit/26328cc6bc09983a8cf5f2c00777617a38c1bf31#diff-58c56482f1d1f4e82fca67ca753b91fa

The other piece of this PR is eliminating the use of `...` in the signature of `cloudml_train` and substituting an explicit `flags` parameter. This provides both syntactic compatibility with `tfruns::training_run` as well as adds support for passing a YAML file with the flags rather than requiring them to specified inline.

This also makes `cloudml_tune()` largely the same function as `cloudml_train()` (as both now sport a `hypertune` parameter). I still think it's worthwhile to have 2 functions though as the `cloudml_tune()` version *requires* the `hypertune` parameter and also provides top-level visibility into hyperparmeter tuning.
