### PR TITLE
Fix warnings in windows to fix #55

### DIFF
--- a/R/gcloud-exec.R
+++ b/R/gcloud-exec.R
@@ -4,7 +4,7 @@ gexec <- function(command,
                   echo = TRUE,
                   throws = TRUE)
 {
-  command <- normalizePath(command)
+  command <- normalizePath(command, mustWork = FALSE)
 
   if (.Platform$OS.type == "windows") {
     args <- c("/c", command, args)


### PR DESCRIPTION
One more fix to close on https://github.com/rstudio/cloudml/issues/55.

Validated in Windows:
- Training, hypertuning and collecting `mnist` example.
- Training and collecting `keras` example.