### PR TITLE
Fix training with alternate cloudml file

### DIFF
--- a/R/scope.R
+++ b/R/scope.R
@@ -81,7 +81,6 @@ scope_deployment <- function(id,
   if (is.list(cloudml))
     yaml::write_yaml(cloudml, file.path(directory, cloudml_file))
   else {
-    cloudml_dir <- dirname(cloudml)
     cloudml_ext <- tools::file_ext(cloudml)
     if (!cloudml_ext %in% c("json", "yml"))
       stop(
@@ -89,8 +88,8 @@ scope_deployment <- function(id,
         cloudml_ext, "' found instead."
       )
 
-    cloudml_file <- paste0("cloudml", cloudml_ext)
-    cloudml_config_path <- file.path(cloudml_dir, cloudml_file)
+    cloudml_file <- paste0("cloudml.", cloudml_ext)
+    cloudml_config_path <- file.path(directory, cloudml_file)
     file.copy(cloudml, cloudml_config_path)
   }
 

--- a/inst/examples/keras/hyper.yml
+++ b/inst/examples/keras/hyper.yml
@@ -1,0 +1,12 @@
+trainingInput:
+  hyperparameters:
+    goal: MAXIMIZE
+    hyperparameterMetricTag: accuracy
+    maxTrials: 2
+    maxParallelTrials: 2
+    params:
+      - parameterName: dropout-rate
+        type: DOUBLE
+        minValue: 0.4
+        maxValue: 0.5
+        scaleType: UNIT_LINEAR_SCALE

--- a/inst/examples/keras/train.R
+++ b/inst/examples/keras/train.R
@@ -1,5 +1,9 @@
 library(keras)
 
+FLAGS <- flags(
+  flag_numeric("dropout_rate", 0.4)
+)
+
 mnist <- dataset_mnist()
 x_train <- mnist$train$x
 y_train <- mnist$train$y
@@ -20,7 +24,7 @@ model <- keras_model_sequential()
 
 model %>%
   layer_dense(units = 256, activation = 'relu', input_shape = c(784)) %>%
-  layer_dropout(rate = 0.4) %>%
+  layer_dropout(rate = FLAGS$dropout_rate) %>%
   layer_dense(units = 128, activation = 'relu') %>%
   layer_dropout(rate = 0.3) %>%
   layer_dense(units = 10, activation = 'softmax')


### PR DESCRIPTION
Should be possible to run:

```
cloudml_train(cloudml = "hyper.yml")
```

While not making `hyper.yml` the default `cloudml.yml` file and opt-in for hyperparameter tunning. Also, adding tuning example for keras.