### PR TITLE
Add support in cloudml_predict() for multiple prediction instances

### DIFF
--- a/R/models.R
+++ b/R/models.R
@@ -2,16 +2,15 @@ cloudml_model_exists <- function(gcloud, name) {
 
   arguments <- (MLArgumentsBuilder(gcloud)
                 ("models")
-                ("list"))
+                ("list")
+                ("--format=json"))
 
   output <- gcloud_exec(args = arguments())
   pasted <- paste(output$stdout, collapse = "\n")
 
-  suppressWarnings({
-    output <- utils::read.table(pasted, header = TRUE, stringsAsFactors = FALSE)
-  })
+  output_parsed <- jsonlite::fromJSON(pasted)
 
-  name %in% output$NAME
+  !is.null(output_parsed$name) && name %in% basename(output_parsed$name)
 }
 
 #' Deploy SavedModel to CloudML

--- a/R/models.R
+++ b/R/models.R
@@ -8,7 +8,7 @@ cloudml_model_exists <- function(gcloud, name) {
   pasted <- paste(output$stdout, collapse = "\n")
 
   suppressWarnings({
-    output <- readr::read_table2(pasted)
+    output <- utils::read.table(pasted, header = TRUE, stringsAsFactors = FALSE)
   })
 
   name %in% output$NAME

--- a/man/cloudml_predict.Rd
+++ b/man/cloudml_predict.Rd
@@ -4,9 +4,12 @@
 \alias{cloudml_predict}
 \title{Perform Prediction over a CloudML Model.}
 \usage{
-cloudml_predict(input, name = NULL, version = NULL, gcloud = NULL)
+cloudml_predict(instances, name = NULL, version = NULL, gcloud = NULL)
 }
 \arguments{
+\item{instances}{A list of instances to be predicted. While predicting
+a single instance, list wrapping this single instance is still expected.}
+
 \item{name}{The name for this model. Defaults to the current directory
 name.}
 


### PR DESCRIPTION
The CloudML API supports (and requires) submitting multiple prediction instances in the REST API and. In the CLI is uses a pseudo-json file consisting of one line per json prediction.

See: https://cloud.google.com/ml-engine/docs/online-predict#formatting_your_input_for_online_prediction