### PR TITLE
Support storing deployed models in storage bucket to fix #91

### DIFF
--- a/R/models.R
+++ b/R/models.R
@@ -52,13 +52,20 @@ cloudml_deploy <- function(
     gcloud_exec(args = arguments())
   }
 
+  model_dest <- sprintf(
+    "%s/models/%s",
+    storage,
+    timestamp_string()
+  )
+
+  gs_copy(export_dir_base, model_dest, recursive = TRUE)
+
   arguments <- (MLArgumentsBuilder(gcloud)
                 ("versions")
                 ("create")
                 (as.character(version))
                 ("--model=%s", name)
-                ("--origin=%s", export_dir_base)
-                ("--staging-bucket=%s", gs_bucket_from_gs_uri(storage))
+                ("--origin=%s", model_dest)
                 ("--runtime-version=%s", cloudml$trainingInput$runtimeVersion %||% "1.4"))
 
   gcloud_exec(args = arguments())


### PR DESCRIPTION
See https://github.com/rstudio/cloudml/issues/91. Adds support to store models under main storage path:

<img width="1166" alt="screen shot 2018-01-03 at 10 49 58 am" src="https://user-images.githubusercontent.com/3478847/34534672-e9615b84-f073-11e7-9674-f9083036efb9.png">

<img width="1163" alt="screen shot 2018-01-03 at 10 50 07 am" src="https://user-images.githubusercontent.com/3478847/34534673-e97c7d38-f073-11e7-8993-6f7104435cc9.png">
