### PR TITLE
Allow account changes in `cloudml_predict()` and `cloudml_train()`

### DIFF
--- a/R/gcloud-storage.R
+++ b/R/gcloud-storage.R
@@ -143,6 +143,26 @@ gs_ensure_storage <- function(gcloud) {
   storage
 }
 
+gs_ensure_account <- function(gcloud) {
+  if (!is.null(gcloud) && !is.null(gcloud$account)) {
+    account <- gexec(
+      gcloud_binary(),
+      c("config", "get-value", "account"),
+      echo = FALSE,
+      throws = FALSE
+    )$stdout
+
+    if (!identical(account, gcloud$account)) {
+      gexec(
+        gcloud_binary(),
+        c("config", "set", "account", gcloud$account),
+        echo = FALSE,
+        throws = FALSE
+      )
+    }
+  }
+}
+
 gs_bucket_from_gs_uri <- function(uri) {
   paste0("gs://", strsplit(sub("gs://", "", uri), "/")[[1]][[1]])
 }

--- a/R/jobs.R
+++ b/R/jobs.R
@@ -36,6 +36,7 @@ cloudml_train <- function(file = "train.R",
 
   gcloud <- gcloud_config(gcloud)
   cloudml <- cloudml_config(cloudml)
+  gs_ensure_account(gcloud)
 
   if (!is.null(master_type)) cloudml$trainingInput$masterType <- master_type
   if (!is.null(cloudml$trainingInput$masterType) &&

--- a/R/models.R
+++ b/R/models.R
@@ -38,6 +38,8 @@ cloudml_deploy <- function(
 
   cloudml <- cloudml_config(cloudml)
   gcloud <- gcloud_config(gcloud)
+
+  gs_ensure_account(gcloud)
   storage <- gs_ensure_storage(gcloud)
 
   if (is.null(gcloud$region)) gcloud$region <- gcloud_default_region()


### PR DESCRIPTION
See https://github.com/rstudio/cloudml/issues/94 - Looks like we can easily switch accounts to support the `gcloud` parameter.