### PR TITLE
Set default region to us-central1 to fix #95

### DIFF
--- a/R/gcloud-config.R
+++ b/R/gcloud-config.R
@@ -55,7 +55,7 @@ gcloud_default_project <- function() {
   trimws(gcloud_exec("config", "get-value", "project")$stdout)
 }
 
-gcloud_default_region <- function(default_region = "us-east1") {
+gcloud_default_region <- function(default_region = "us-central1") {
   region <- trimws(
     gexec(
       gcloud_binary(),

--- a/dev/packrat/cloudml.yml
+++ b/dev/packrat/cloudml.yml
@@ -1,7 +1,7 @@
 gcloud:
   project         : "project-name"
   account         : "account@domain.com"
-  region          : "us-east1"
+  region          : "us-central1"
 
 cloudml:
   storage         : "gs://project-name/packrat"

--- a/docs/articles/training.html
+++ b/docs/articles/training.html
@@ -35,7 +35,7 @@
 <li class="dropdown">
   <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">
     Guides
-     
+
     <span class="caret"></span>
   </a>
   <ul class="dropdown-menu" role="menu">
@@ -61,7 +61,7 @@
 <li>
   <a href="https://github.com/rstudio/cloudml">
     <span class="fa fa-github"></span>
-     
+
   </a>
 </li>
       </ul>
@@ -72,16 +72,16 @@
 </div>
 <!--/.navbar -->
 
-      
+
       </header><div class="row">
   <div class="col-md-9">
     <div class="page-header toc-ignore">
       <h1>Training with CloudML</h1>
-            
+
           </div>
 
-    
-    
+
+
 <div class="contents">
 <div id="overview" class="section level2">
 <h2 class="hasAnchor">
@@ -129,7 +129,7 @@ job &lt;-<span class="st"> </span><span class="kw"><a href="../reference/cloudml
  $ state         : chr "RUNNING"
  $ trainingInput :List of 3
   ..$ jobDir        : chr "gs://cedar-card-791/r-cloudml/staging"
-  ..$ region        : chr "us-east1"
+  ..$ region        : chr "us-central1"
   ..$ runtimeVersion: chr "1.4"
  $ trainingOutput:List of 1
   ..$ consumedMLUnits: num 0.04

--- a/vignettes/training.Rmd
+++ b/vignettes/training.Rmd
@@ -71,7 +71,7 @@ job_status(job)
  $ state         : chr "RUNNING"
  $ trainingInput :List of 3
   ..$ jobDir        : chr "gs://cedar-card-791/r-cloudml/staging"
-  ..$ region        : chr "us-east1"
+  ..$ region        : chr "us-central1"
   ..$ runtimeVersion: chr "1.4"
  $ trainingOutput:List of 1
   ..$ consumedMLUnits: num 0.04


### PR DESCRIPTION
See https://github.com/rstudio/cloudml/issues/95.

Looks like the beta instances are now available in `us-central1` which does not require contacting support to enable GPU instances.