### PR TITLE
Support for all-users gcloud installs in windows

### DIFF
--- a/R/gcloud-install.R
+++ b/R/gcloud-install.R
@@ -30,8 +30,8 @@ gcloud_binary <- function() {
 
     candidates <- c(
       function() file.path(appdata, "Google/Cloud SDK/google-cloud-sdk/bin/gcloud.cmd"),
-      function() file.path(Sys.getenv("ProgramFiles"), "/Google/Cloud SDK/google-cloud-sdk/gcloud.cmd"),
-      function() file.path(Sys.getenv("ProgramFiles(x86)"), "/Google/Cloud SDK/google-cloud-sdk/gcloud.cmd")
+      function() file.path(Sys.getenv("ProgramFiles"), "/Google/Cloud SDK/google-cloud-sdk/bin/gcloud.cmd"),
+      function() file.path(Sys.getenv("ProgramFiles(x86)"), "/Google/Cloud SDK/google-cloud-sdk/bin/gcloud.cmd")
     )
   } else {
     candidates <- c(

--- a/R/gcloud-install.R
+++ b/R/gcloud-install.R
@@ -30,7 +30,8 @@ gcloud_binary <- function() {
 
     candidates <- c(
       function() file.path(appdata, "Google/Cloud SDK/google-cloud-sdk/bin/gcloud.cmd"),
-      function() file.path(Sys.getenv("ProgramFiles"), "/Google/Cloud SDK/google-cloud-sdk/gcloud.cmd")
+      function() file.path(Sys.getenv("ProgramFiles"), "/Google/Cloud SDK/google-cloud-sdk/gcloud.cmd"),
+      function() file.path(Sys.getenv("ProgramFiles(x86)"), "/Google/Cloud SDK/google-cloud-sdk/gcloud.cmd")
     )
   } else {
     candidates <- c(

--- a/R/gcloud-install.R
+++ b/R/gcloud-install.R
@@ -30,7 +30,7 @@ gcloud_binary <- function() {
 
     candidates <- c(
       function() file.path(appdata, "Google/Cloud SDK/google-cloud-sdk/bin/gcloud.cmd"),
-      function() file.path(Sys.getenv("ProgramFiles"), "/Google/Cloud SDK/google-cloud-sdk/bin.cmd")
+      function() file.path(Sys.getenv("ProgramFiles"), "/Google/Cloud SDK/google-cloud-sdk/gcloud.cmd")
     )
   } else {
     candidates <- c(

--- a/R/gcloud-install.R
+++ b/R/gcloud-install.R
@@ -24,17 +24,20 @@ gcloud_binary <- function() {
   if (!is.null(user_path))
     return(normalizePath(user_path))
 
-  candidates <- c(
-    function() Sys.which("gcloud"),
-    function() "~/google-cloud-sdk/bin/gcloud",
-    function() file.path(gcloud_binary_default(), "bin/gcloud")
-  )
-
   if (.Platform$OS.type == "windows") {
     appdata <- normalizePath(Sys.getenv("localappdata"), winslash = "/")
     win_path <- file.path(appdata, "Google/Cloud SDK/google-cloud-sdk/bin/gcloud.cmd")
-    if (file.exists(win_path))
-      return(file.path(appdata, "Google/\"Cloud SDK\"/google-cloud-sdk/bin/gcloud.cmd"))
+
+    candidates <- c(
+      function() file.path(appdata, "Google/Cloud SDK/google-cloud-sdk/bin/gcloud.cmd"),
+      function() file.path(Sys.getenv("ProgramFiles"), "/Google/Cloud SDK/google-cloud-sdk/bin.cmd")
+    )
+  } else {
+    candidates <- c(
+      function() Sys.which("gcloud"),
+      function() "~/google-cloud-sdk/bin/gcloud",
+      function() file.path(gcloud_binary_default(), "bin/gcloud")
+    )
   }
 
   for (candidate in candidates)


### PR DESCRIPTION
Fix for https://github.com/rstudio/cloudml/issues/115, Windows GCloud installer comes in two flavours:

<img width="499" alt="screen shot 2018-02-04 at 8 57 54 pm" src="https://user-images.githubusercontent.com/3478847/35789639-52b971a6-09f2-11e8-8ae0-5df8421db619.png">

This change adds support for the `all-users` option.