### PR TITLE
Add support for categorical variables in hyper-parameter tuning status

### DIFF
--- a/R/jobs.R
+++ b/R/jobs.R
@@ -367,8 +367,15 @@ job_trials_from_status <- function(status) {
 
   df <- do.call("rbind", lapply(status$trainingOutput$trials, as.data.frame, stringsAsFactors = FALSE))
 
-  for(col in colnames(df))
-    df[[col]] <- as.numeric(df[[col]])
+  for(col in colnames(df)) {
+    is_numeric <- suppressWarnings(
+      !any(is.na(as.numeric(df$hyperparameters.parameter)))
+    )
+
+    if (is_numeric) {
+      df[[col]] <- as.numeric(df[[col]])
+    }
+  }
 
   df
 }


### PR DESCRIPTION
See https://github.com/rstudio/tfdeploy/issues/3

Collection for categorical variables now works...

```
> cloudml::job_trials("cloudml_2018_02_06_181554794")
  finalMetric.objectiveValue finalMetric.trainingStep hyperparameters.dropout1 hyperparameters.parameter trialId
1                   0.974083                       19       0.5502279910831227             learning_rate       1
2                   0.973417                       19      0.58071153621337968             learning_rate       2
```