### PR TITLE
Add support for verbose under cloudml_predict to fix #112

### DIFF
--- a/R/models.R
+++ b/R/models.R
@@ -85,7 +85,7 @@ cloudml_deploy <- function(
 #'
 #' @param instances A list of instances to be predicted. While predicting
 #'   a single instance, list wrapping this single instance is still expected.
-#' @param instances Should additional information be reported?
+#' @param verbose Should additional information be reported?
 #'
 #' @seealso [cloudml_deploy()]
 #'

--- a/R/models.R
+++ b/R/models.R
@@ -85,6 +85,7 @@ cloudml_deploy <- function(
 #'
 #' @param instances A list of instances to be predicted. While predicting
 #'   a single instance, list wrapping this single instance is still expected.
+#' @param instances Should additional information be reported?
 #'
 #' @seealso [cloudml_deploy()]
 #'
@@ -92,7 +93,8 @@ cloudml_deploy <- function(
 cloudml_predict <- function(
   instances,
   name,
-  version = paste0(name, "_1")) {
+  version = paste0(name, "_1"),
+  verbose = FALSE) {
 
   default_name <- basename(normalizePath(getwd(), winslash = "/"))
   if (is.null(name)) name <- default_name
@@ -108,6 +110,13 @@ cloudml_predict <- function(
     as.character(jsonlite::toJSON(instance, auto_unbox = TRUE))
   })
   writeLines(paste(all_json, collapse = "\n"), pseudo_json_file)
+
+  if (identical(verbose, TRUE)) {
+    message("Prediction Request:")
+    message("")
+    sapply(all_json, message)
+    message("")
+  }
 
   arguments <- (MLArgumentsBuilder(gcloud)
                 ("predict")

--- a/man/cloudml_predict.Rd
+++ b/man/cloudml_predict.Rd
@@ -4,7 +4,8 @@
 \alias{cloudml_predict}
 \title{Perform Prediction over a CloudML Model.}
 \usage{
-cloudml_predict(instances, name, version = paste0(name, "_1"))
+cloudml_predict(instances, name, version = paste0(name, "_1"),
+  verbose = FALSE)
 }
 \arguments{
 \item{instances}{A list of instances to be predicted. While predicting
@@ -14,6 +15,8 @@ a single instance, list wrapping this single instance is still expected.}
 
 \item{version}{The version for this model. Versions start with a letter and
 contain only letters, numbers and underscores. Defaults to name_1}
+
+\item{instances}{Should additional information be reported?}
 }
 \description{
 Perform online prediction over a CloudML model, usually, created using

--- a/man/cloudml_predict.Rd
+++ b/man/cloudml_predict.Rd
@@ -16,7 +16,7 @@ a single instance, list wrapping this single instance is still expected.}
 \item{version}{The version for this model. Versions start with a letter and
 contain only letters, numbers and underscores. Defaults to name_1}
 
-\item{instances}{Should additional information be reported?}
+\item{verbose}{Should additional information be reported?}
 }
 \description{
 Perform online prediction over a CloudML model, usually, created using


### PR DESCRIPTION
See #112, this adds support for `verbose` in `cloudml_predict()`, as in:

```r
> cloudml_predict(list(list(input1 = 1, input2 = 2), list(input1 = 1, input2 = 2)), "tfdeploy", "keras_multiple", verbose = TRUE)
Prediction Request:

{"input1":1,"input2":2}
{"input1":1,"input2":2}

Prediction 1:
$output1
[1] 3

$output2
[1] 3

Prediction 2:
$output1
[1] 3

$output2
[1] 3
```