### PR TITLE
Fix check for categorical

### DIFF
--- a/R/jobs.R
+++ b/R/jobs.R
@@ -369,7 +369,7 @@ job_trials_from_status <- function(status) {
 
   for(col in colnames(df)) {
     is_numeric <- suppressWarnings(
-      !any(is.na(as.numeric(df$hyperparameters.parameter)))
+      !any(is.na( as.numeric(df[[col]])))
     )
 
     if (is_numeric) {


### PR DESCRIPTION
This will return the categorical responses from the job_status response list.  Now it coerces each column, then verifies if the coercion caused NAs, if yes then it returns "FALSE" for the the is_numeric. I think this was your original intention with the update.

The original verification step always returned "TRUE."

Changes with updates (printed "col" and "is_numeric" for each loop to confirm). 

![image](https://user-images.githubusercontent.com/25038837/35986130-3a62eee4-0cc6-11e8-8e44-5bd1e987dd3e.png)
