### PR TITLE
Use full path in gcloud_init to avoid waiting for PATH envvar changes and fix #123 

### DIFF
--- a/R/terminal.R
+++ b/R/terminal.R
@@ -78,7 +78,12 @@ gcloud_terminal <- function(command = NULL, clear = FALSE) {
 #' @export
 gcloud_init <- function() {
   if (have_rstudio_terminal()) {
-    gcloud_terminal("gcloud init")
+    gcloud_terminal(
+      paste(
+        shQuote(gcloud_binary()),
+        "init"
+      )
+    )
   } else {
     gcloud_init_message()
   }

--- a/inst/cloudml/setup.py
+++ b/inst/cloudml/setup.py
@@ -137,6 +137,14 @@ class CustomCommands(install):
     # Run regular install
     install.run(self)
 
+def find_files(directory):
+  result = []
+  for root, dirs, files in os.walk(directory):
+    for filename in files:
+      filename = os.path.join(root, filename)
+      result.append(os.path.relpath(filename, directory))
+  return result
+
 REQUIRED_PACKAGES = []
 
 setup(
@@ -146,7 +154,7 @@ setup(
     author_email     = "author@example.com",
     install_requires = REQUIRED_PACKAGES,
     packages         = find_packages(),
-    package_data     = {"": ["*"]},
+    package_data     = {"": find_files(os.path.join(__file__, os.path.dirname(os.path.abspath(__file__)), "cloudml-model")) },
     description      = "RStudio Integration",
     requires         = [],
     cmdclass         = { "install": CustomCommands }

--- a/inst/cloudml/setup.py
+++ b/inst/cloudml/setup.py
@@ -44,7 +44,29 @@ CUSTOM_COMMANDS = {
         ["apt-get", "-qq", "-m", "-y", "install", "libcurl4-openssl-dev", "libxml2-dev", "libxslt-dev", "libssl-dev", "r-base", "r-base-dev"],
     ],
     "debian": [
+        # Upgrade R
+        ["touch", "/etc/apt/sources.list"],
+        ["sed", "-i", "$ a\deb http://cran.rstudio.com/bin/linux/debian stretch-cran34/", "/etc/apt/sources.list"],
+        ["cat", "/etc/apt/sources.list"],
+        ["apt-key", "adv", "--keyserver", "keys.gnupg.net", "--recv-key", "E19F5F87128899B192B1A2C2AD5F960A256A04AF"],
 
+        # Update repositories
+        ["apt-get", "-qq", "-m", "-y", "update", "--fix-missing"],
+
+        # Upgrading packages could be useful but takes about 30-60s additional seconds
+        ["apt-get", "-qq", "-m", "-y", "upgrade"],
+
+        # Install R dependencies
+        ["apt-get", "-qq", "-m", "-y", "install", "libcurl4-openssl-dev", "libxml2-dev", "libxslt-dev", "libssl-dev"],
+
+        ["apt-get", "-qq", "-m", "-y", "update", "--fix-missing"],
+
+        ["apt-get", "-qq", "-m", "-y", "clean"],
+        ["apt-get", "-qq", "-m", "-y", "autoclean"],
+
+        ["apt-get", "-qq", "-m", "-y", "install", "aptitude"],
+        ["aptitude", "--assume-yes", "install", "r-base"],
+        ["aptitude", "--assume-yes", "install", "r-base-dev"]
     ]
 }
 
@@ -98,8 +120,8 @@ class CustomCommands(install):
     print("linux_distribution: %s" % (distro,))
 
     distro_key = distro[0].lower()
-    if (distro_key in CUSTOM_COMMANDS.keys()):
-      raise ValueError(distro[0] + " is currently not supported, please report this under github.com/rstudio/cloudml/issues")
+    if (not distro_key in CUSTOM_COMMANDS.keys()):
+      raise ValueError("'" + distro[0] + "' is currently not supported, please report this under github.com/rstudio/cloudml/issues")
     custom_os_commands = CUSTOM_COMMANDS[distro_key]
 
     self.LoadJobConfig()


### PR DESCRIPTION
See #123

The Google installer adds gcloud to the PATH but restarting the rsession does not read the PATH changes until RStudio is restarted, fix is to use the full path rather than relying on the PATH.