### PR TITLE
Make gcloud path optional while installing from rstudio terminal

### DIFF
--- a/R/terminal.R
+++ b/R/terminal.R
@@ -43,9 +43,14 @@ gcloud_terminal <- function(command = NULL, clear = FALSE) {
     }
   }
 
+  gcloud_path <- tryCatch({
+    gcloud_binary()
+  }, error = function(e) {
+    ""
+  })
 
   # launch terminal with cloud sdk on the PATH
-  withr::with_path(gcloud_binary(), {
+  withr::with_path(gcloud_path, {
 
     if (length(gcloud_terminals) > 0) {
 


### PR DESCRIPTION
Under RStudio's terminal, if the gcloud bin is not available, the installation fails. Outside RStudio's terminal, `gcloud_install()` installs properly otherwise.