### PR TITLE
Source bash profile in gcloud_install to fix #140

### DIFF
--- a/R/gcloud-install.R
+++ b/R/gcloud-install.R
@@ -99,7 +99,7 @@ gcloud_install_unix <- function() {
                               paste0("--install-dir=",
                                      path.expand(dirname(gcloud_binary))))),
                           collapse = " ")
-    terminal_command <- paste(install_args, "&&", "gcloud", "init")
+    terminal_command <- paste(install_args, "&&", "source", "~/.bash_profile", "&&", "gcloud", "init")
     gcloud_terminal(terminal_command, clear = TRUE)
 
   } else {

--- a/R/gcloud-install.R
+++ b/R/gcloud-install.R
@@ -99,7 +99,7 @@ gcloud_install_unix <- function() {
                               paste0("--install-dir=",
                                      path.expand(dirname(gcloud_binary))))),
                           collapse = " ")
-    terminal_command <- paste(install_args, "&&", "source", "~/.bash_profile", "&&", "gcloud", "init")
+    terminal_command <- paste(install_args, "&&", "(source", "~/.bash_profile", "||", "true)", "&&", "gcloud", "init")
     gcloud_terminal(terminal_command, clear = TRUE)
 
   } else {


### PR DESCRIPTION
See #140, sourcing the bash profile is required to avoid having to call `gcloud_install()` twice in Linux systems.