### PR TITLE
 Bump minimum version to 1.6 in cloudml_deploy()

### DIFF
--- a/R/cloudml-package.R
+++ b/R/cloudml-package.R
@@ -35,7 +35,7 @@
 #' For documentation on using the R interface to CloudML see the package website
 #' at <https://tensorflow.rstudio.com/tools/cloudml/>
 #'
-#' @references https://tensorflow.rstudio.com/tools/cloudml/
+#' @references <https://tensorflow.rstudio.com/tools/cloudml/>
 #' @name cloudml-package
 #' @aliases cloudml
 #' @keywords internal

--- a/R/jobs.R
+++ b/R/jobs.R
@@ -93,7 +93,7 @@ cloudml_train <- function(file = "train.R",
                 ("--job-dir=%s", file.path(storage, "staging"))
                 ("--package-path=%s", basename(directory))
                 ("--module-name=%s.cloudml.deploy", basename(directory))
-                ("--runtimeVersion=%s", cloudml_version)
+                ("--runtime-version=%s", cloudml_version)
                 ("--region=%s", region)
                 ("--config=%s/%s", "cloudml-model", cloudml_file)
                 ("--")

--- a/R/jobs.R
+++ b/R/jobs.R
@@ -24,11 +24,6 @@
 #'   (blocks waiting for the job to complete). The default (`"ask"`) will
 #'   interactively prompt the user whether to collect the results or not.
 #'
-#' @param runtime_version The version number of the Cloud Machine Learning
-#'   platform to use (see
-#'   <https://cloud.google.com/ml-engine/docs/tensorflow/runtime-version-list>
-#'   for valid values).  Defaults to "1.6"
-#'
 #' @seealso [job_status()], [job_collect()], [job_cancel()]
 #'
 #' @family CloudML functions
@@ -38,8 +33,7 @@ cloudml_train <- function(file = "train.R",
                           flags = NULL,
                           region = NULL,
                           config = NULL,
-                          collect = "ask",
-                          runtime_version)
+                          collect = "ask")
 {
   message("Submitting training job to CloudML...")
 
@@ -87,11 +81,8 @@ cloudml_train <- function(file = "train.R",
   scope_setup_py(directory)
   setwd(dirname(directory))
 
-  cloudml_version <- if (!missing(runtime_version)  && !is.null(runtime_version)) {
-    runtime_version
-  } else {
-    cloudml$trainingInput$runtimeVersion %||% "1.6"
-  }
+  cloudml_version <- cloudml$trainingInput$runtimeVersion %||% "1.6"
+
   if (utils::compareVersion(cloudml_version, "1.4") < 0)
     stop("CloudML version ", cloudml_version, " is unsupported, use 1.4 or newer.")
 

--- a/R/jobs.R
+++ b/R/jobs.R
@@ -12,13 +12,13 @@
 #' @param master_type Training master node machine type. "standard" provides a
 #'   basic machine configuration suitable for training simple models with small
 #'   to moderate datasets. See the documentation at
-#'   https://cloud.google.com/ml-engine/docs/training-overview#machine_type_table
+#'   <https://cloud.google.com/ml-engine/docs/training-overview#machine_type_table>
 #'    for details on available machine types.
 #'
 #' @param region The region to be used for training.
 #'
 #' @param config A list, `YAML` or `JSON` configuration file as described
-#'   https://cloud.google.com/ml-engine/reference/rest/v1/projects.jobs.
+#'   <https://cloud.google.com/ml-engine/reference/rest/v1/projects.jobs>.
 #'
 #' @param collect Collect job when training is completed (blocks waiting for the
 #'   job to complete).

--- a/R/jobs.R
+++ b/R/jobs.R
@@ -93,7 +93,7 @@ cloudml_train <- function(file = "train.R",
                 ("--job-dir=%s", file.path(storage, "staging"))
                 ("--package-path=%s", basename(directory))
                 ("--module-name=%s.cloudml.deploy", basename(directory))
-                ("--runtime-version=%s", cloudml_version)
+                ("--runtimeVersion=%s", cloudml_version)
                 ("--region=%s", region)
                 ("--config=%s/%s", "cloudml-model", cloudml_file)
                 ("--")

--- a/R/jobs.R
+++ b/R/jobs.R
@@ -20,8 +20,14 @@
 #' @param config A list, `YAML` or `JSON` configuration file as described
 #'   <https://cloud.google.com/ml-engine/reference/rest/v1/projects.jobs>.
 #'
-#' @param collect Collect job when training is completed (blocks waiting for the
-#'   job to complete).
+#' @param collect Logical. If TRUE, collect job when training is completed
+#'   (blocks waiting for the job to complete). The default (`"ask"`) will
+#'   interactively prompt the user whether to collect the results or not.
+#'
+#' @param runtime_version The version number of the Cloud Machine Learning
+#'   platform to use (see
+#'   <https://cloud.google.com/ml-engine/docs/tensorflow/runtime-version-list>
+#'   for valid values).  Defaults to "1.6"
 #'
 #' @seealso [job_status()], [job_collect()], [job_cancel()]
 #'
@@ -32,7 +38,8 @@ cloudml_train <- function(file = "train.R",
                           flags = NULL,
                           region = NULL,
                           config = NULL,
-                          collect = "ask")
+                          collect = "ask",
+                          runtime_version)
 {
   message("Submitting training job to CloudML...")
 
@@ -80,7 +87,11 @@ cloudml_train <- function(file = "train.R",
   scope_setup_py(directory)
   setwd(dirname(directory))
 
-  cloudml_version <- cloudml$trainingInput$runtimeVersion %||% "1.4"
+  cloudml_version <- if (!missing(runtime_version)  && !is.null(runtime_version)) {
+    runtime_version
+  } else {
+    cloudml$trainingInput$runtimeVersion %||% "1.6"
+  }
   if (utils::compareVersion(cloudml_version, "1.4") < 0)
     stop("CloudML version ", cloudml_version, " is unsupported, use 1.4 or newer.")
 

--- a/man/cloudml-package.Rd
+++ b/man/cloudml-package.Rd
@@ -31,7 +31,7 @@ For documentation on using the R interface to CloudML see the package website
 at \url{https://tensorflow.rstudio.com/tools/cloudml/}
 }
 \references{
-https://tensorflow.rstudio.com/tools/cloudml/
+\url{https://tensorflow.rstudio.com/tools/cloudml/}
 }
 \author{
 \strong{Maintainer}: Javier Luraschi \email{javier@rstudio.com}

--- a/man/cloudml_deploy.Rd
+++ b/man/cloudml_deploy.Rd
@@ -20,7 +20,7 @@ contain only letters, numbers and underscores. Defaults to name_1}
 \item{region}{The region to be used to deploy this model.}
 
 \item{config}{A list, \code{YAML} or \code{JSON} configuration file as described
-https://cloud.google.com/ml-engine/reference/rest/v1/projects.jobs.}
+\url{https://cloud.google.com/ml-engine/reference/rest/v1/projects.jobs}.}
 }
 \description{
 Deploys a SavedModel to CloudML model for online predictions.

--- a/man/cloudml_train.Rd
+++ b/man/cloudml_train.Rd
@@ -5,7 +5,7 @@
 \title{Train a model using Cloud ML}
 \usage{
 cloudml_train(file = "train.R", master_type = NULL, flags = NULL,
-  region = NULL, config = NULL, collect = "ask", runtime_version)
+  region = NULL, config = NULL, collect = "ask")
 }
 \arguments{
 \item{file}{File to be used as entrypoint for training.}
@@ -27,11 +27,6 @@ to YAML file containing flag values.}
 \item{collect}{Logical. If TRUE, collect job when training is completed
 (blocks waiting for the job to complete). The default (\code{"ask"}) will
 interactively prompt the user whether to collect the results or not.}
-
-\item{runtime_version}{The version number of the Cloud Machine Learning
-platform to use (see
-\url{https://cloud.google.com/ml-engine/docs/tensorflow/runtime-version-list}
-for valid values).  Defaults to "1.4"}
 }
 \description{
 Upload a TensorFlow application to Google Cloud, and use that application to

--- a/man/cloudml_train.Rd
+++ b/man/cloudml_train.Rd
@@ -5,7 +5,7 @@
 \title{Train a model using Cloud ML}
 \usage{
 cloudml_train(file = "train.R", master_type = NULL, flags = NULL,
-  region = NULL, config = NULL, collect = "ask")
+  region = NULL, config = NULL, collect = "ask", runtime_version)
 }
 \arguments{
 \item{file}{File to be used as entrypoint for training.}
@@ -24,8 +24,14 @@ to YAML file containing flag values.}
 \item{config}{A list, \code{YAML} or \code{JSON} configuration file as described
 \url{https://cloud.google.com/ml-engine/reference/rest/v1/projects.jobs}.}
 
-\item{collect}{Collect job when training is completed (blocks waiting for the
-job to complete).}
+\item{collect}{Logical. If TRUE, collect job when training is completed
+(blocks waiting for the job to complete). The default (\code{"ask"}) will
+interactively prompt the user whether to collect the results or not.}
+
+\item{runtime_version}{The version number of the Cloud Machine Learning
+platform to use (see
+\url{https://cloud.google.com/ml-engine/docs/tensorflow/runtime-version-list}
+for valid values).  Defaults to "1.4"}
 }
 \description{
 Upload a TensorFlow application to Google Cloud, and use that application to

--- a/man/cloudml_train.Rd
+++ b/man/cloudml_train.Rd
@@ -13,7 +13,7 @@ cloudml_train(file = "train.R", master_type = NULL, flags = NULL,
 \item{master_type}{Training master node machine type. "standard" provides a
 basic machine configuration suitable for training simple models with small
 to moderate datasets. See the documentation at
-https://cloud.google.com/ml-engine/docs/training-overview#machine_type_table
+\url{https://cloud.google.com/ml-engine/docs/training-overview#machine_type_table}
 for details on available machine types.}
 
 \item{flags}{Named list with flag values (see \code{\link[=flags]{flags()}}) or path
@@ -22,7 +22,7 @@ to YAML file containing flag values.}
 \item{region}{The region to be used for training.}
 
 \item{config}{A list, \code{YAML} or \code{JSON} configuration file as described
-https://cloud.google.com/ml-engine/reference/rest/v1/projects.jobs.}
+\url{https://cloud.google.com/ml-engine/reference/rest/v1/projects.jobs}.}
 
 \item{collect}{Collect job when training is completed (blocks waiting for the
 job to complete).}


### PR DESCRIPTION
This fixes inconsistencies in newest version of keras that caused TensorFlow to crash. Using runtime version 1.6 fixes this.

Also, add proper HTML tags to links in help, so they show up as hyperlinks.
