### PR TITLE
Warning in Windows when RStudio not configured to use a command prompt

### DIFF
--- a/R/terminal.R
+++ b/R/terminal.R
@@ -87,6 +87,17 @@ gcloud_terminal <- function(command = NULL, clear = FALSE) {
     }
 
     id <- rstudioapi::terminalCreate(gcloud_sdk_terminal)
+
+    terminal_shell <- rstudioapi::terminalContext(id)$shell
+    if (identical(tolower(.Platform$OS.type), "windows") &&
+        !startsWith(terminal_shell, "Command Prompt")) {
+      warning(
+        "'cloudml' requires RStudio's terminal to be configured to use the 'Command Prompt' ",
+        "but it's currently configured to use '", terminal_shell, "'. You can change ",
+        "this setting from Tools - Global Options - Terminal."
+      )
+    }
+
     init_terminal(id)
   })
 


### PR DESCRIPTION
Warning in Windows when RStudio is not configured to use a command prompt terminal. See #155 and #152.