### PR TITLE
Fix config.yml for keras example

### DIFF
--- a/inst/examples/keras/tuning.yml
+++ b/inst/examples/keras/tuning.yml
@@ -5,6 +5,7 @@ trainingInput:
     goal: MAXIMIZE
     hyperparameterMetricTag: val_acc
     maxTrials: 2
+    max_parallel_trials: 2
     params:
       - parameterName: dropout1
         type: DOUBLE


### PR DESCRIPTION
Add `max_parallel_trials: 2` to `config.yml`, because CloudML won't run without this. #149