### PR TITLE
WIP: Update hyperparameter examples to run in updated cloudml

### DIFF
--- a/dev/census/hypertune.yml
+++ b/dev/census/hypertune.yml
@@ -1,8 +1,10 @@
 # Define how we want to optimize hyperparameters.
 goal: MAXIMIZE
 hyperparameterMetricTag: accuracy
-maxTrials: 4
-maxParallelTrials: 2
+maxTrials:
+  - 4
+maxParallelTrials:
+  - 2
 
 # Define the hyperparameters we want to search over.
 params:

--- a/inst/examples/keras/tuning.yml
+++ b/inst/examples/keras/tuning.yml
@@ -4,7 +4,10 @@ trainingInput:
   hyperparameters:
     goal: MAXIMIZE
     hyperparameterMetricTag: val_acc
-    maxTrials: 2
+    maxTrials:
+      - 2
+    maxParallelTrials:
+      - 2
     params:
       - parameterName: dropout1
         type: DOUBLE

--- a/inst/examples/mnist/tuning.yml
+++ b/inst/examples/mnist/tuning.yml
@@ -2,8 +2,10 @@ trainingInput:
   hyperparameters:
     goal: MAXIMIZE
     hyperparameterMetricTag: accuracy
-    maxTrials: 2
-    maxParallelTrials: 2
+    maxTrials:
+      - 2
+    maxParallelTrials:
+      - 2
     params:
       - parameterName: learning_rate
         type: DOUBLE

--- a/inst/examples/tfestimators/tuning.yml
+++ b/inst/examples/tfestimators/tuning.yml
@@ -2,8 +2,10 @@ trainingInput:
   hyperparameters:
     goal: MINIMIZE
     hyperparameterMetricTag: average_loss
-    maxTrials: 2
-    maxParallelTrials: 2
+    maxTrials:
+      - 2
+    maxParallelTrials:
+      - 2
     params:
       - parameterName: num-epochs
         type: INTEGER

--- a/vignettes/tuning.Rmd
+++ b/vignettes/tuning.Rmd
@@ -126,7 +126,10 @@ trainingInput:
   hyperparameters:
     goal: MAXIMIZE
     hyperparameterMetricTag: acc
-    maxTrials: 10
+    maxTrials:
+      - 10
+    maxParallelTrials:
+      - 2
     params:
       - parameterName: dropout1
         type: DOUBLE


### PR DESCRIPTION
Currently, hyperparameter tuning examples don't work. Reached out to Google folks since this seems like a regression, but opening this PR in case it's not.