### PR TITLE
Trigger gcloud init in default gcloud_install() under os x

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # cloudml 0.6.0 (unreleased)
 
 - Fixed `gcloud_install()` to properly execute `gcloud init` in RStudio
-  terminal under OS X (#177).
+  terminal under Linux (#177).
 
 - Fixed `gs_rsync()` to avoid creating a local destination directory when 
   destination uses remote storage (#172).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # cloudml 0.6.0 (unreleased)
 
+- Fixed `gcloud_install()` to properly execute `gcloud init` in RStudio
+  terminal under OS X (#177).
+
 - Fixed `gs_rsync()` to avoid creating a local destination directory when 
   destination uses remote storage (#172).
 

--- a/R/gcloud-install.R
+++ b/R/gcloud-install.R
@@ -107,12 +107,9 @@ gcloud_install_unix <- function() {
                                      path.expand(dirname(gcloud_binary))))),
                           collapse = " ")
 
-    if (Sys.info()["sysname"] == "Darwin") {
-      terminal_command <- paste(install_args, "&&", "source", "~/.bash_profile", "&&", "gcloud", "init")
-    }
-    else {
-      terminal_command <- paste(install_args, "&&", "(source", "~/.bash_profile", "||", "true)", "&&", "gcloud", "init")
-    }
+    bash_file <- ifelse(Sys.info()["sysname"] == "Darwin", "~/.bash_profile", "~/.bashrc")
+
+    terminal_command <- paste(install_args, "&&", "source", bash_file, "&&", "gcloud", "init")
 
     gcloud_terminal(terminal_command, clear = TRUE)
 

--- a/R/gcloud-install.R
+++ b/R/gcloud-install.R
@@ -106,7 +106,14 @@ gcloud_install_unix <- function() {
                               paste0("--install-dir=",
                                      path.expand(dirname(gcloud_binary))))),
                           collapse = " ")
-    terminal_command <- paste(install_args, "&&", "(source", "~/.bash_profile", "||", "true)", "&&", "gcloud", "init")
+
+    if (Sys.info()["sysname"] == "Darwin") {
+      terminal_command <- paste(install_args, "&&", "source", "~/.bash_profile", "&&", "gcloud", "init")
+    }
+    else {
+      terminal_command <- paste(install_args, "&&", "(source", "~/.bash_profile", "||", "true)", "&&", "gcloud", "init")
+    }
+
     gcloud_terminal(terminal_command, clear = TRUE)
 
   } else {


### PR DESCRIPTION
See https://github.com/rstudio/cloudml/issues/177, triggering `gcloud_install()` in OS X does not trigger `gcloud init` in blank setups.