### PR TITLE
Default to TensorFlow 1.9 runtime

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # cloudml 0.6.0 (unreleased)
 
+- Default to the TensorFlow 1.9 runtime. Previous runtimes can be used
+  through `runtimeVersion` in `config.yml`.
+
 - Fixed `gs_rsync()` to avoid creating a local destination directory when 
   destination uses remote storage (#172).
 

--- a/R/jobs.R
+++ b/R/jobs.R
@@ -97,7 +97,7 @@ cloudml_train <- function(file = "train.R",
   scope_setup_py(directory)
   setwd(dirname(directory))
 
-  cloudml_version <- cloudml$trainingInput$runtimeVersion %||% "1.6"
+  cloudml_version <- cloudml$trainingInput$runtimeVersion %||% "1.9"
 
   if (utils::compareVersion(cloudml_version, "1.4") < 0)
     stop("CloudML version ", cloudml_version, " is unsupported, use 1.4 or newer.")


### PR DESCRIPTION
Validated that `mnist` works against `1.9`, waiting for test run to also validate `keras` example against `1.9`. Runtime `1.6` can still be selected by using `config.yml`:

```yml
trainingInput:
  runtimeVersion: "1.6"
```

and `cloudml_train(config = "config.yml")`.