### PR TITLE
Read IGNORED from `cloudml.ignore.packages` option

### DIFF
--- a/R/scope.R
+++ b/R/scope.R
@@ -15,8 +15,7 @@ initialize_application <- function(application = getwd(), dry_run = FALSE)
   )
 
   # We manage a set of packages during deploy that might require specific versions
-  IGNORED <- c(
-  )
+  IGNORED <- getOption("cloudml.ignored.packages", c())
 
   packrat::opts$ignored.packages(IGNORED)
   packrat::.snapshotImpl(


### PR DESCRIPTION
This allows to exclude private packages from the packrat mechanism. See the issue https://github.com/rstudio/cloudml/issues/171 why this is useful.