### PR TITLE
Allow absolute entrypoint paths that are still relative paths

### DIFF
--- a/R/jobs.R
+++ b/R/jobs.R
@@ -64,6 +64,9 @@ cloudml_train <- function(file = "train.R",
   application <- getwd()
   entrypoint <- file
 
+  # allow absolute paths under relative path
+  entrypoint <- gsub(paste0("^", getwd(), .Platform$file.sep), "", entrypoint)
+
   # prepare application for deployment
   id <- unique_job_name("cloudml")
   deployment <- scope_deployment(


### PR DESCRIPTION
Fix for https://github.com/rstudio/cloudml/issues/182. `cloudml` requires relative paths to properly bring your project to Google Cloud; however, should be OK to provide an absolute path hat is still relative to the current project.