### PR TITLE
Use a default config if no config is provided via an yml file or list.

### DIFF
--- a/R/jobs.R
+++ b/R/jobs.R
@@ -60,6 +60,11 @@ cloudml_train <- function(file = "train.R",
       !identical(cloudml$trainingInput$scaleTier, "CUSTOM"))
     cloudml$trainingInput$scaleTier <- "CUSTOM"
 
+  # use the basic tier when no configuration is passed via file or via
+  # the `config` argument.
+  if (length(cloudml) == 0L)
+    cloudml$trainingInput <- list(scaleTier = "BASIC")
+
   # set application and entrypoint
   application <- getwd()
   entrypoint <- file


### PR DESCRIPTION
This fixes #197

If we pass no config file, we end up with a configuration file with just []. This is interpreted as a list by pyyaml (not a dictionary) and may be returning this error 'list' object has no attribute 'get'