### PR TITLE
Allow the user to specify custom OS commands

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@
 - Use ai-platform instead of ml-engine when user have a recent enought Google
   Cloud SDK.
 
+- Added the `customCommands` flag in the `cloudml.yml` file to allow users to
+  pass custom OS commands before packages installation. This could be used to
+  install custom system dependencies.
+
 # cloudml 0.6.0
 
 - Fixed `gcloud_install()` to properly execute `gcloud init` in RStudio

--- a/R/jobs.R
+++ b/R/jobs.R
@@ -65,6 +65,10 @@ cloudml_train <- function(file = "train.R",
   if (length(cloudml) == 0L)
     cloudml$trainingInput <- list(scaleTier = "BASIC")
 
+  # Get the customCOmmands field from the config file.
+  custom_commands <- cloudml[["customCommands"]]
+  cloudml[["customCommands"]] <- NULL
+
   # set application and entrypoint
   application <- getwd()
   entrypoint <- file
@@ -97,7 +101,8 @@ cloudml_train <- function(file = "train.R",
   # pass parameters to the job
   job_yml <- file.path(deployment$directory, "job.yml")
   yaml::write_yaml(list(
-    storage = storage
+    storage = storage,
+    custom_commands = custom_commands
   ), job_yml)
 
   # move to deployment parent directory and spray __init__.py

--- a/inst/cloudml/setup.py
+++ b/inst/cloudml/setup.py
@@ -81,6 +81,7 @@ PIP_INSTALL_KERAS = [
 class CustomCommands(install):
   cache = ""
   config = {}
+  custom_os_commands = []
 
   """A setuptools Command class able to run arbitrary commands."""
   def RunCustomCommand(self, commands, throws):
@@ -109,6 +110,8 @@ class CustomCommands(install):
 
     stream = open(cloudmlpath, "r")
     self.config = yaml.load(stream)
+    if (self.config['custom_commands'] is not None):
+      self.custom_os_commands += self.config['custom_commands']
 
   """Runs a list of arbitrary commands"""
   def RunCustomCommandList(self, commands):
@@ -122,12 +125,12 @@ class CustomCommands(install):
     distro_key = distro[0].lower()
     if (not distro_key in CUSTOM_COMMANDS.keys()):
       raise ValueError("'" + distro[0] + "' is currently not supported, please report this under github.com/rstudio/cloudml/issues")
-    custom_os_commands = CUSTOM_COMMANDS[distro_key]
+    self.custom_os_commands = CUSTOM_COMMANDS[distro_key]
 
     self.LoadJobConfig()
 
     # Run custom commands
-    self.RunCustomCommandList(custom_os_commands)
+    self.RunCustomCommandList(self.custom_os_commands)
 
     # Run pip install
     if (not "keras" in self.config or self.config["keras"] == True):

--- a/inst/examples/custom_command/cloudml.yml
+++ b/inst/examples/custom_command/cloudml.yml
@@ -1,0 +1,5 @@
+customCommands:
+  - ["pip", "install", "Pillow"]
+trainingInput:
+  scaleTier: BASIC
+

--- a/inst/examples/custom_command/example.R
+++ b/inst/examples/custom_command/example.R
@@ -1,0 +1,5 @@
+library(tensorflow)
+library(reticulate)
+
+tensorflow::tf_config()
+pillow <- reticulate::import("PIL")

--- a/tests/testthat/test-train.R
+++ b/tests/testthat/test-train.R
@@ -63,6 +63,7 @@ test_that("cloudml_train() can use a custom command command", {
   with_temp_training_dir(system.file("examples/custom_command", package = "cloudml"), {
     options(repos=structure(c(CRAN="https://cloud.r-project.org/")))
 
+    cloudml_write_config()
     job <- cloudml_train("example.R", config = "cloudml.yml")
     expect_train_succeeds(job, saves_model = FALSE)
   })

--- a/tests/testthat/test-train.R
+++ b/tests/testthat/test-train.R
@@ -58,3 +58,13 @@ test_that("cloudml_train() can train keras model", {
   })
 
 })
+
+test_that("cloudml_train() can use a custom command command", {
+  with_temp_training_dir(system.file("examples/custom_command", package = "cloudml"), {
+    options(repos=structure(c(CRAN="https://cloud.r-project.org/")))
+
+    job <- cloudml_train("example.R", config = "cloudml.yml")
+    expect_train_succeeds(job, saves_model = FALSE)
+  })
+
+})


### PR DESCRIPTION
By adding a the `customCommands` flag to `cloudml.yml` the user can now run any custom command before installing the R packages:

For example:

```
customCommands:
  - ["pip", "install", "Pillow"]
```

Fixes #188 