### PR TITLE
Set the default version of runtime to 2.1 and Python to 3.7

### DIFF
--- a/R/jobs.R
+++ b/R/jobs.R
@@ -110,7 +110,7 @@ cloudml_train <- function(file = "train.R",
   scope_setup_py(directory)
   setwd(dirname(directory))
 
-  cloudml_version <- cloudml$trainingInput$runtimeVersion %||% "2.1"
+  cloudml_version <- cloudml$trainingInput$runtimeVersion %||% "1.15"
 
   if (utils::compareVersion(cloudml_version, "1.4") < 0)
     stop("CloudML version ", cloudml_version, " is unsupported, use 1.4 or newer.")
@@ -125,7 +125,7 @@ cloudml_train <- function(file = "train.R",
                 ("--package-path=%s", basename(directory))
                 ("--module-name=%s.cloudml.deploy", basename(directory))
                 ("--runtime-version=%s", cloudml_version)
-                ("--python-version=3.5")
+                ("--python-version=2.7")
                 ("--region=%s", region)
                 ("--config=%s/%s", "cloudml-model", cloudml_file)
                 ("--")

--- a/R/jobs.R
+++ b/R/jobs.R
@@ -125,7 +125,7 @@ cloudml_train <- function(file = "train.R",
                 ("--package-path=%s", basename(directory))
                 ("--module-name=%s.cloudml.deploy", basename(directory))
                 ("--runtime-version=%s", cloudml_version)
-                ("--python-version=2.7")
+                ("--python-version=3.7")
                 ("--region=%s", region)
                 ("--config=%s/%s", "cloudml-model", cloudml_file)
                 ("--")

--- a/R/jobs.R
+++ b/R/jobs.R
@@ -110,7 +110,7 @@ cloudml_train <- function(file = "train.R",
   scope_setup_py(directory)
   setwd(dirname(directory))
 
-  cloudml_version <- cloudml$trainingInput$runtimeVersion %||% "1.9"
+  cloudml_version <- cloudml$trainingInput$runtimeVersion %||% "2.1"
 
   if (utils::compareVersion(cloudml_version, "1.4") < 0)
     stop("CloudML version ", cloudml_version, " is unsupported, use 1.4 or newer.")
@@ -125,6 +125,7 @@ cloudml_train <- function(file = "train.R",
                 ("--package-path=%s", basename(directory))
                 ("--module-name=%s.cloudml.deploy", basename(directory))
                 ("--runtime-version=%s", cloudml_version)
+                ("--python-version=3.5")
                 ("--region=%s", region)
                 ("--config=%s/%s", "cloudml-model", cloudml_file)
                 ("--")

--- a/inst/cloudml/cloudml/deploy.py
+++ b/inst/cloudml/cloudml/deploy.py
@@ -37,7 +37,7 @@ process = subprocess.Popen(
 
 # Stream output from subprocess to console.
 for line in iter(process.stdout.readline, ""):
-  sys.stdout.write(line)
+  sys.stdout.write(line.decode('ascii'))
 
 # Finalize the process.
 stdout, stderr = process.communicate()

--- a/inst/cloudml/cloudml/deploy.py
+++ b/inst/cloudml/cloudml/deploy.py
@@ -37,7 +37,7 @@ process = subprocess.Popen(
 
 # Stream output from subprocess to console.
 for line in iter(process.stdout.readline, ""):
-  sys.stdout.write(line.decode('ascii'))
+  sys.stdout.write(line.decode('utf-8'))
 
 # Finalize the process.
 stdout, stderr = process.communicate()

--- a/inst/cloudml/cloudml/deploy.py
+++ b/inst/cloudml/cloudml/deploy.py
@@ -37,7 +37,7 @@ process = subprocess.Popen(
 
 # Stream output from subprocess to console.
 for line in iter(process.stdout.readline, ""):
-  sys.stdout.write(line.decode('utf-8'))
+  sys.stdout.write(line)
 
 # Finalize the process.
 stdout, stderr = process.communicate()


### PR DESCRIPTION
The default version 1.9 of the runtime [ended its availability](https://cloud.google.com/ai-platform/training/docs/runtime-version-list) on March 16, 2020. Therefore, the default version of the runtime is set to 2.1, which requires to be used in conjunction with Python 3.7. 

In line 40 of `deploy.py`, the function `sys.stdout.write()` throws an error (`write()` argument must be `str`, not `bytes`), when it is executed under Python 3.7 (instead of Python 2.7). The `line`  should be decoded into `str` using `utf-8` encoding. 